### PR TITLE
feat: 支持自适应RSI阈值

### DIFF
--- a/quant_trade/utils/config.yaml
+++ b/quant_trade/utils/config.yaml
@@ -1,6 +1,7 @@
 risk_filters_enabled: true
 dynamic_threshold_enabled: true
 direction_filters_enabled: false
+rsi_k: 1.5  # RSI 阈值标准差倍数
 filter_penalty_mode: true
 penalty_factor: 0.5
 enable_ai: true


### PR DESCRIPTION
## Summary
- 新增 `adaptive_rsi_threshold` 用于计算滚动均值±k倍标准差的RSI动态上下界
- 使用自适应RSI阈值替换固定30/70判断并引入`rsi_k`配置参数

## Testing
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6896b6b96574832aa2562e41f854be13