### PR TITLE
feat: add cvar risk limit

### DIFF
--- a/backtest_alpha.py
+++ b/backtest_alpha.py
@@ -1,0 +1,34 @@
+"""对比不同 CVaR alpha 下策略表现的简单回测脚本"""
+
+from pathlib import Path
+import pandas as pd
+from quant_trade.backtester import run_backtest
+
+ALPHAS = [0.05, 0.1, 0.2]
+
+
+def main():
+    results = []
+    for alpha in ALPHAS:
+        print(f"Running backtest with alpha={alpha}")
+        run_backtest(cvar_alpha=alpha)
+        summary_path = Path(__file__).resolve().parent / "backtest_fusion_summary.csv"
+        if summary_path.exists():
+            df = pd.read_csv(summary_path)
+            total_ret = df["total_ret"].sum()
+            sharpe = df["sharpe"].mean()
+            trades = df["n_trades"].sum()
+            results.append(
+                {
+                    "alpha": alpha,
+                    "total_ret": total_ret,
+                    "sharpe": sharpe,
+                    "trades": trades,
+                }
+            )
+    if results:
+        print(pd.DataFrame(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/quant_trade/backtester.py
+++ b/quant_trade/backtester.py
@@ -161,8 +161,10 @@ def calc_equity_curve(trades_df: pd.DataFrame) -> pd.Series:
 
 # =========== 融合信号回测 ===========
 def run_backtest(
-    *, recent_days: int | None = None,
+    *,
+    recent_days: int | None = None,
     start_time: pd.Timestamp | str | None = None,
+    cvar_alpha: float | None = None,
 ) -> None:
     cfg = load_config()
     engine = connect_mysql(cfg)
@@ -198,6 +200,8 @@ def run_backtest(
     all_symbols = df['symbol'].unique().tolist()
     rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
     sg = RobustSignalGenerator(rsg_cfg)
+    if cvar_alpha is not None:
+        sg.cvar_alpha = cvar_alpha
 
     # 根据近期历史数据更新因子 IC 分数
     sg.update_ic_scores(df.tail(1000), group_by="symbol")

--- a/quant_trade/risk_manager.py
+++ b/quant_trade/risk_manager.py
@@ -1,6 +1,27 @@
 import numpy as np
 
 
+def cvar_limit(pnl_history: list[float] | np.ndarray, alpha: float) -> float:
+    """计算给定损益序列在 ``alpha`` 分位下的 CVaR。
+
+    Args:
+        pnl_history: 账户历史损益列表，正为盈利、负为亏损。
+        alpha: 分位数（如 ``0.05`` 表示 5% 分位）。
+
+    Returns:
+        在 ``alpha`` 分位以下的平均损益，负值代表预期亏损。
+    """
+
+    arr = np.asarray(pnl_history, dtype=float)
+    if arr.size == 0:
+        return 0.0
+
+    var = np.quantile(arr, alpha)
+    tail = arr[arr <= var]
+    cvar = tail.mean() if tail.size else var
+    return float(cvar)
+
+
 class RiskManager:
     """风险控制逻辑"""
 

--- a/tests/test_cvar_limit.py
+++ b/tests/test_cvar_limit.py
@@ -1,0 +1,68 @@
+import pytest
+from quant_trade.tests.test_utils import make_dummy_rsg
+from tests.test_overbought_oversold import make_cache, base_inputs
+
+
+class DummyAccount:
+    def __init__(self, pnl):
+        self.pnl_history = pnl
+
+    def day_loss_pct(self):
+        return 0.0
+
+
+def _run_finalize(rsg):
+    (
+        risk_info,
+        ai_scores,
+        fs,
+        scores,
+        std_1h,
+        std_4h,
+        std_d1,
+        std_15m,
+        raw_f1h,
+        raw_f4h,
+        raw_f15m,
+    ) = base_inputs()
+    cache = make_cache()
+    return rsg.finalize_position(
+        0.5,
+        risk_info,
+        risk_info["logic_score"],
+        risk_info["env_score"],
+        ai_scores,
+        fs,
+        scores,
+        std_1h,
+        std_4h,
+        std_d1,
+        std_15m,
+        raw_f1h,
+        raw_f4h,
+        {},
+        raw_f15m,
+        {},
+        {},
+        {},
+        short_mom=0,
+        ob_imb=0,
+        confirm_15m=0,
+        extreme_reversal=False,
+        cache=cache,
+        symbol=None,
+    )
+
+
+def test_finalize_position_skips_on_negative_cvar():
+    rsg = make_dummy_rsg()
+    rsg.account = DummyAccount([-0.1, -0.05, 0.02, 0.03])
+    rsg.cvar_alpha = 0.25
+    assert _run_finalize(rsg) is None
+
+
+def test_finalize_position_allows_when_cvar_positive():
+    rsg = make_dummy_rsg()
+    rsg.account = DummyAccount([0.1, 0.05, 0.02, 0.03])
+    rsg.cvar_alpha = 0.25
+    assert _run_finalize(rsg) is not None


### PR DESCRIPTION
## Summary
- add `cvar_limit` for CVaR calculation
- guard trading in `finalize_position` using dynamic CVaR check
- expose CVaR alpha in backtester and provide evaluation script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bac7ff68832a81334bce42f3a688