### PR TITLE
refactor: extract factor scoring

### DIFF
--- a/quant_trade/param_search.py
+++ b/quant_trade/param_search.py
@@ -43,7 +43,7 @@ def compute_ic_scores(df: pd.DataFrame, rsg: RobustSignalGenerator) -> dict:
             ai_score = rsg.predictor.get_ai_score_cls(feats, models_1h["cls"])
         else:
             ai_score = 0.0
-        factors = rsg.get_factor_scores(feats, "1h")
+        factors = rsg.factor_scorer.score(feats, "1h")
         data = {"ai": ai_score, **factors}
         for k in scores:
             scores[k].append(data.get(k, np.nan))

--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -33,6 +33,7 @@ from .utils import (
     sigmoid_confidence,
 )
 from .voting_model import VotingModel, load_cached_model
+from .factor_scorer import FactorScorerImpl
 
 __all__ = [
     "SignalThresholdParams",
@@ -65,4 +66,5 @@ __all__ = [
     "sigmoid_confidence",
     "VotingModel",
     "load_cached_model",
+    "FactorScorerImpl",
 ]

--- a/quant_trade/signal/factor_scorer.py
+++ b/quant_trade/signal/factor_scorer.py
@@ -1,0 +1,287 @@
+import logging
+from collections.abc import Mapping
+import numpy as np
+
+from .utils import adjust_score, volume_guard
+
+logger = logging.getLogger(__name__)
+
+
+class FactorScorerImpl:
+    """封装因子得分相关逻辑的实现类"""
+
+    def __init__(self, core):
+        """参数
+        ------
+        core : RobustSignalGenerator
+            主体对象实例, 用于访问共享的方法与属性
+        """
+        self.core = core
+
+    # 原 get_factor_scores -> score
+    def score(self, features: Mapping, period: str) -> dict:
+        key = self.core._make_cache_key(features, period)
+        cached = self.core._cache_get(self.core._factor_cache, key)
+        if cached is not None:
+            return cached
+
+        dedup_row = {k: v for k, v in features.items()}
+        safe = lambda k, d=0: self.core.get_feat_value(dedup_row, k, d)
+
+        trend_raw = (
+            np.tanh(safe(f"price_vs_ma200_{period}", 0) * 5)
+            + np.tanh(safe(f"ema_slope_50_{period}", 0) * 5)
+            + 0.5 * np.tanh(safe(f"adx_{period}", 0) / 50)
+        )
+
+        momentum_raw = (
+            (safe(f"rsi_{period}", 50) - 50) / 50
+            + np.tanh(safe(f"macd_hist_{period}", 0) * 5)
+        )
+
+        volatility_raw = (
+            np.tanh(safe(f"atr_pct_{period}", 0) * 8)
+            + np.tanh(safe(f"bb_width_{period}", 0) * 2)
+        )
+
+        volume_raw = (
+            np.tanh(safe(f"vol_ma_ratio_{period}", 0))
+            + np.tanh((safe(f"buy_sell_ratio_{period}", 1) - 1) * 2)
+        )
+
+        sentiment_raw = np.tanh(safe(f"funding_rate_{period}", 0) * 4000)
+
+        f_rate = safe(f"funding_rate_{period}", 0)
+        f_anom = safe(f"funding_rate_anom_{period}", 0)
+        thr = 0.0005
+        if abs(f_rate) > thr:
+            funding_raw = -np.tanh(f_rate * 4000)
+        else:
+            funding_raw = np.tanh(f_rate * 4000)
+        if abs(f_rate) < 0.001:
+            funding_raw = 0.0
+        funding_raw += np.tanh(f_anom * 50)
+
+        scores = {
+            "trend": np.tanh(trend_raw),
+            "momentum": np.tanh(momentum_raw),
+            "volatility": np.tanh(volatility_raw),
+            "volume": np.tanh(volume_raw),
+            "sentiment": np.tanh(sentiment_raw),
+            "funding": np.tanh(funding_raw),
+        }
+
+        pos = safe(f"channel_pos_{period}", 0.5)
+        for k, v in scores.items():
+            if pos > 1 and v > 0:
+                scores[k] = v * 1.2
+            elif pos < 0 and v < 0:
+                scores[k] = v * 1.2
+            elif pos > 0.9 and v > 0:
+                scores[k] = v * 0.8
+            elif pos < 0.1 and v < 0:
+                scores[k] = v * 0.8
+
+        self.core._cache_set(self.core._factor_cache, key, scores)
+        return scores
+
+    # 原 calc_factor_scores
+    def calc_factor_scores(self, ai_scores: dict, factor_scores: dict, weights: dict) -> dict:
+        w1 = weights.copy()
+        w4 = weights.copy()
+        for k in ("trend", "momentum", "volume"):
+            w1[k] = w1.get(k, 0) * 0.7
+            w4[k] = w4.get(k, 0) * 0.7
+        scores = {
+            "1h": self.core.combine_score(ai_scores["1h"], factor_scores["1h"], w1),
+            "4h": self.core.combine_score(ai_scores["4h"], factor_scores["4h"], w4),
+            "d1": self.core.combine_score(ai_scores["d1"], factor_scores["d1"], weights),
+        }
+        logger.debug("factor scores: %s", scores)
+        return scores
+
+    # 原 calc_factor_scores_vectorized
+    def calc_factor_scores_vectorized(self, ai_scores: dict, factor_scores: dict, weights: dict) -> dict:
+        w1 = weights.copy()
+        w4 = weights.copy()
+        for k in ("trend", "momentum", "volume"):
+            w1[k] = w1.get(k, 0) * 0.7
+            w4[k] = w4.get(k, 0) * 0.7
+        return {
+            "1h": self.core.combine_score_vectorized(ai_scores["1h"], factor_scores["1h"], w1),
+            "4h": self.core.combine_score_vectorized(ai_scores["4h"], factor_scores["4h"], w4),
+            "d1": self.core.combine_score_vectorized(ai_scores["d1"], factor_scores["d1"], weights),
+        }
+
+    # 原 apply_local_adjustments
+    def apply_local_adjustments(
+        self,
+        scores: dict,
+        raw_feats: dict,
+        factor_scores: dict,
+        deltas: dict,
+        rise_pred_1h: float | None = None,
+        drawdown_pred_1h: float | None = None,
+        symbol: str | None = None,
+    ) -> tuple[dict, dict]:
+        adjusted = scores.copy()
+        details = {}
+
+        for p in adjusted:
+            adjusted[p] = self.core._apply_delta_boost(adjusted[p], deltas.get(p, {}))
+
+        prev_ma20 = raw_feats["1h"].get("sma_20_1h_prev")
+        ma_coeff = self.core.ma_cross_logic(raw_feats["1h"], prev_ma20)
+        adjusted["1h"] *= ma_coeff
+        details["ma_cross"] = int(np.sign(ma_coeff - 1.0))
+
+        if rise_pred_1h is not None and drawdown_pred_1h is not None:
+            delta = rise_pred_1h - abs(drawdown_pred_1h)
+            if delta >= 0.01:
+                adj = np.tanh(delta * 5) * 0.5
+                adjusted["1h"] *= 1 + adj
+                details["rise_drawdown_adj"] = adj
+            else:
+                details["rise_drawdown_adj"] = 0.0
+
+        strong_confirm_4h = (
+            factor_scores["4h"]["trend"] > 0
+            and factor_scores["4h"]["momentum"] > 0
+            and factor_scores["4h"]["volatility"] > 0
+            and adjusted["4h"] > 0
+        ) or (
+            factor_scores["4h"]["trend"] < 0
+            and factor_scores["4h"]["momentum"] < 0
+            and factor_scores["4h"]["volatility"] < 0
+            and adjusted["4h"] < 0
+        )
+        details["strong_confirm_4h"] = strong_confirm_4h
+
+        macd_diff = raw_feats["1h"].get("macd_hist_diff_1h_4h")
+        rsi_diff = raw_feats["1h"].get("rsi_diff_1h_4h")
+        if (
+            macd_diff is not None
+            and rsi_diff is not None
+            and macd_diff < 0
+            and rsi_diff < -8
+        ):
+            if strong_confirm_4h:
+                logger.debug(
+                    "momentum misalign macd_diff=%.3f rsi_diff=%.3f -> strong_confirm=False",
+                    macd_diff,
+                    rsi_diff,
+                )
+            strong_confirm_4h = False
+            details["strong_confirm_4h"] = False
+
+        if (
+            macd_diff is not None
+            and rsi_diff is not None
+            and abs(macd_diff) < 5
+            and abs(rsi_diff) < 15
+        ):
+            strong_confirm_4h = True
+            details["strong_confirm_4h"] = True
+
+        for p in ["1h", "4h", "d1"]:
+            sent = factor_scores[p]["sentiment"]
+            before = adjusted[p]
+            adjusted[p] = adjust_score(
+                adjusted[p],
+                sent,
+                self.core.sentiment_alpha,
+                cap_scale=self.core.cap_positive_scale,
+            )
+            if before != adjusted[p]:
+                logger.debug(
+                    "sentiment %.2f adjust %s: %.3f -> %.3f",
+                    sent,
+                    p,
+                    before,
+                    adjusted[p],
+                )
+
+        params = self.core.volume_guard_params.copy()
+        q_low, q_high = self.core.get_volume_ratio_thresholds(symbol)
+        params["ratio_low"] = q_low
+        params["ratio_high"] = q_high
+        r1 = raw_feats["1h"].get("vol_ma_ratio_1h")
+        roc1 = raw_feats["1h"].get("vol_roc_1h")
+        before = adjusted["1h"]
+        adjusted["1h"] = volume_guard(adjusted["1h"], r1, roc1, **params)
+        if before != adjusted["1h"]:
+            logger.debug(
+                "volume guard 1h ratio=%.3f roc=%.3f -> %.3f",
+                r1,
+                roc1,
+                adjusted["1h"],
+            )
+        if raw_feats.get("4h") is not None:
+            r4 = raw_feats["4h"].get("vol_ma_ratio_4h")
+            roc4 = raw_feats["4h"].get("vol_roc_4h")
+            before4 = adjusted["4h"]
+            adjusted["4h"] = volume_guard(adjusted["4h"], r4, roc4, **params)
+            if before4 != adjusted["4h"]:
+                logger.debug(
+                    "volume guard 4h ratio=%.3f roc=%.3f -> %.3f",
+                    r4,
+                    roc4,
+                    adjusted["4h"],
+                )
+        r_d1 = raw_feats["d1"].get("vol_ma_ratio_d1")
+        roc_d1 = raw_feats["d1"].get("vol_roc_d1")
+        before_d1 = adjusted["d1"]
+        adjusted["d1"] = volume_guard(adjusted["d1"], r_d1, roc_d1, **params)
+        if before_d1 != adjusted["d1"]:
+            logger.debug(
+                "volume guard d1 ratio=%.3f roc=%.3f -> %.3f",
+                r_d1,
+                roc_d1,
+                adjusted["d1"],
+            )
+
+        for p in ["1h", "4h", "d1"]:
+            bs = raw_feats[p].get(f"break_support_{p}")
+            br = raw_feats[p].get(f"break_resistance_{p}")
+            before_sr = adjusted[p]
+            if br:
+                adjusted[p] *= 1.1 if adjusted[p] > 0 else 0.8
+            if bs:
+                adjusted[p] *= 1.1 if adjusted[p] < 0 else 0.8
+            if before_sr != adjusted[p]:
+                logger.debug(
+                    "break SR %s bs=%s br=%s %.3f->%.3f",
+                    p,
+                    bs,
+                    br,
+                    before_sr,
+                    adjusted[p],
+                )
+                details[f"break_sr_{p}"] = adjusted[p] - before_sr
+
+        for p in ["1h", "4h", "d1"]:
+            perc = raw_feats[p].get(f"boll_perc_{p}")
+            vol_ratio = raw_feats[p].get(f"vol_ma_ratio_{p}")
+            before_bb = adjusted[p]
+            if (
+                perc is not None
+                and vol_ratio is not None
+                and vol_ratio > 1.5
+                and (perc >= 0.98 or perc <= 0.02)
+            ):
+                if perc >= 0.98:
+                    adjusted[p] *= 1.1 if adjusted[p] > 0 else 0.9
+                else:
+                    adjusted[p] *= 1.1 if adjusted[p] < 0 else 0.9
+            if before_bb != adjusted[p]:
+                logger.debug(
+                    "boll breakout %s perc=%.3f vol_ratio=%.3f %.3f->%.3f",
+                    p,
+                    perc,
+                    vol_ratio,
+                    before_bb,
+                    adjusted[p],
+                )
+                details[f"boll_breakout_{p}"] = adjusted[p] - before_bb
+
+        return adjusted, details

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -1,12 +1,15 @@
 import pytest
 
-from collections import deque
+from collections import deque, OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal.predictor_adapter import PredictorAdapter
+from quant_trade.signal.factor_scorer import FactorScorerImpl
 
 
 def make_dummy_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg._factor_cache = OrderedDict()
+    rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)
 

--- a/tests/test_fe_rsg_integration.py
+++ b/tests/test_fe_rsg_integration.py
@@ -39,7 +39,7 @@ def test_feature_engineer_to_rsg_signal(monkeypatch):
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, u, d: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: 0.2
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)

--- a/tests/test_new_funcs.py
+++ b/tests/test_new_funcs.py
@@ -12,7 +12,7 @@ def test_calc_factor_scores():
         '4h': {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0, 'sentiment': 0, 'funding': 0},
         'd1': {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0, 'sentiment': 0, 'funding': 0},
     }
-    scores = rsg.calc_factor_scores(ai, fs, rsg.base_weights)
+    scores = rsg.factor_scorer.calc_factor_scores(ai, fs, rsg.base_weights)
     w1 = rsg.base_weights.copy()
     for k in ('trend', 'momentum', 'volume'):
         w1[k] *= 0.7
@@ -42,7 +42,7 @@ def test_apply_local_adjustments():
         'd1': {'sentiment': 0},
     }
     deltas = {'1h': {'rsi_1h_delta': 0.01}}
-    adjusted, det = rsg.apply_local_adjustments(scores, raw, fs, deltas, 0.1, -0.05)
+    adjusted, det = rsg.factor_scorer.apply_local_adjustments(scores, raw, fs, deltas, 0.1, -0.05)
     assert 'ma_cross' in det
     assert 'strong_confirm_4h' in det
     assert 'boll_breakout_1h' in det
@@ -71,9 +71,9 @@ def test_rise_drawdown_adj_threshold():
         'd1': {'sentiment': 0},
     }
     deltas = {}
-    adj_high, det_high = rsg.apply_local_adjustments(scores, raw, fs, deltas, 0.02, -0.005)
+    adj_high, det_high = rsg.factor_scorer.apply_local_adjustments(scores, raw, fs, deltas, 0.02, -0.005)
     assert det_high['rise_drawdown_adj'] > 0
-    adj_low, det_low = rsg.apply_local_adjustments(scores, raw, fs, deltas, 0.008, -0.0)
+    adj_low, det_low = rsg.factor_scorer.apply_local_adjustments(scores, raw, fs, deltas, 0.008, -0.0)
     assert det_low['rise_drawdown_adj'] == 0
 
 
@@ -99,7 +99,7 @@ def test_rise_drawdown_adj_threshold_exact():
         'd1': {'sentiment': 0},
     }
     deltas = {}
-    _, det_eq = rsg.apply_local_adjustments(scores, raw, fs, deltas, 0.02, 0.01)
+    _, det_eq = rsg.factor_scorer.apply_local_adjustments(scores, raw, fs, deltas, 0.02, 0.01)
     assert det_eq['rise_drawdown_adj'] > 0
 
 
@@ -123,8 +123,8 @@ def test_fuse_multi_cycle():
 def test_ai_dir_inconsistent_returns_none():
     rsg = make_dummy_rsg()
     rsg.ai_dir_eps = 0.1
-    rsg.calc_factor_scores = lambda ai, fs, w: ai
-    rsg.apply_local_adjustments = lambda s, *a, **k: (s, {})
+    rsg.factor_scorer.calc_factor_scores = lambda ai, fs, w: ai
+    rsg.factor_scorer.apply_local_adjustments = lambda s, *a, **k: (s, {})
     pf = PeriodFeatures({}, {})
     res = rsg.compute_factor_scores(
         {"1h": 0.3, "4h": -0.3, "d1": 0.3},
@@ -147,8 +147,8 @@ def test_ai_dir_inconsistent_returns_none():
 def test_ai_dir_eps_threshold_check():
     rsg = make_dummy_rsg()
     rsg.ai_dir_eps = 0.2
-    rsg.calc_factor_scores = lambda ai, fs, w: ai
-    rsg.apply_local_adjustments = lambda s, *a, **k: (s, {})
+    rsg.factor_scorer.calc_factor_scores = lambda ai, fs, w: ai
+    rsg.factor_scorer.apply_local_adjustments = lambda s, *a, **k: (s, {})
     pf = PeriodFeatures({}, {})
     res = rsg.compute_factor_scores(
         {"1h": 0.15, "4h": -0.3, "d1": 0.25},

--- a/tests/test_oi_reversal_crowding.py
+++ b/tests/test_oi_reversal_crowding.py
@@ -28,7 +28,7 @@ def test_detect_reversal_adjusts_threshold():
     rsg.dynamic_threshold = dyn_th
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda *a, **k: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: ai
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},

--- a/tests/test_range_strong_filter.py
+++ b/tests/test_range_strong_filter.py
@@ -6,7 +6,7 @@ def setup_rsg():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.5
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,5 +1,5 @@
 import pytest
-from collections import deque
+from collections import deque, OrderedDict
 
 from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
@@ -8,10 +8,13 @@ from quant_trade.robust_signal_generator import (
     adjust_score,
 )
 from quant_trade.signal.predictor_adapter import PredictorAdapter
+from quant_trade.signal.factor_scorer import FactorScorerImpl
 
 
 def make_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg._factor_cache = OrderedDict()
+    rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)
     rsg.symbol_categories = {}
@@ -60,7 +63,7 @@ def test_vol_roc_guard():
     rsg = make_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.5
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -188,7 +188,7 @@ def test_generate_signal_raw_atr():
     rsg.ic_scores = {k: 1 for k in rsg.base_weights}
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.9
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 1,
         'momentum': 1,
         'volatility': 1,
@@ -241,7 +241,7 @@ def test_dynamic_threshold_use_raw_features():
 
     rsg.dynamic_threshold = fake_dyn_th
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -294,7 +294,7 @@ def test_factor_scores_use_normalized_features():
         return {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0,
                 'sentiment': 0, 'funding': 0}
 
-    rsg.get_factor_scores = fake_get_factor_scores
+    rsg.factor_scorer.score = fake_get_factor_scores
     rsg.predictor.get_ai_score = lambda f, up, down: 0
     rsg.combine_score = lambda ai, fs, weights=None: 0
     rsg.dynamic_weight_update = lambda: rsg.base_weights
@@ -440,7 +440,7 @@ def test_generate_signal_with_external_metrics():
     base = make_dummy_rsg()
     for r in (base,):
         r.predictor.get_ai_score = lambda f, up, down: 0
-        r.get_factor_scores = lambda f, p: {
+        r.factor_scorer.score = lambda f, p: {
             'trend': 0,
             'momentum': 0,
             'volatility': 0,
@@ -466,7 +466,7 @@ def test_generate_signal_with_external_metrics():
 
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = base.predictor.get_ai_score
-    rsg.get_factor_scores = base.get_factor_scores
+    rsg.factor_scorer.score = base.factor_scorer.score
     rsg.combine_score = base.combine_score
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = base.dynamic_threshold
@@ -493,7 +493,7 @@ def test_generate_signal_with_external_metrics():
 def test_hot_sector_influence():
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -535,7 +535,7 @@ def test_hot_sector_influence():
 def test_eth_dominance_influence():
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -578,7 +578,7 @@ def test_eth_dominance_influence():
 def test_short_momentum_and_order_book():
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -623,7 +623,7 @@ def test_short_momentum_and_order_book():
 def test_ma_cross_logic_amplify():
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -724,7 +724,7 @@ def test_order_book_momentum_threshold():
     """小幅盘口差异不应取消已生成的信号"""
     rsg = make_dummy_rsg()
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -781,7 +781,7 @@ def test_sentiment_reweight_and_guard():
         return {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0,
                 'sentiment': 0, 'funding': 0}
 
-    rsg.get_factor_scores = fs_func
+    rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
@@ -815,7 +815,7 @@ def test_volume_and_funding_penalties():
         return {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0,
                 'sentiment': 0, 'funding': 0}
 
-    rsg.get_factor_scores = fs_func
+    rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
@@ -858,7 +858,7 @@ def test_momentum_alignment_disables_confirm():
         return {'trend': 0, 'momentum': 0, 'volatility': 0,
                 'volume': 0, 'sentiment': 0, 'funding': 0}
 
-    rsg.get_factor_scores = fs_func
+    rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
@@ -898,7 +898,7 @@ def test_crowding_factor_and_dynamic_threshold():
                 'volume': 0, 'sentiment': -0.6 if period == '1h' else 0,
                 'funding': 0}
 
-    rsg.get_factor_scores = fs_func
+    rsg.factor_scorer.score = fs_func
     rsg.get_dynamic_oi_threshold = lambda pred_vol=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
@@ -937,7 +937,7 @@ def test_step_exit_with_order_book_flip():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
@@ -993,7 +993,7 @@ def test_position_size_range_regime():
         return -0.2
 
     rsg.predictor.get_ai_score = fake_ai
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0, 'momentum': 0, 'volatility': 0,
         'volume': 0, 'sentiment': 0, 'funding': 0,
     }
@@ -1032,7 +1032,7 @@ def test_generate_signal_with_cls_model():
 
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score_cls = lambda feats, mdl: 0.5
-    rsg.get_factor_scores = lambda f, p: {
+    rsg.factor_scorer.score = lambda f, p: {
         'trend': 0,
         'momentum': 0,
         'volatility': 0,
@@ -1077,7 +1077,7 @@ def test_conflict_filter_and_pos_size():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.0
-    rsg.get_factor_scores = lambda f, p: {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0,
+    rsg.factor_scorer.score = lambda f, p: {'trend': 0, 'momentum': 0, 'volatility': 0, 'volume': 0,
                                           'sentiment': 0, 'funding': 0}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.10, 0.0)
@@ -1111,7 +1111,7 @@ def test_extreme_indicator_scales_down():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.6
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.10, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
@@ -1146,7 +1146,7 @@ def test_vote_conflict_scales_score():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0.6
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
@@ -1185,7 +1185,7 @@ def test_confirm_15m_adjusts_score():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)

--- a/tests/test_signal_generator_batch.py
+++ b/tests/test_signal_generator_batch.py
@@ -1,9 +1,13 @@
 import types
+from collections import OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
+from quant_trade.signal.factor_scorer import FactorScorerImpl
 
 
 def test_generate_signal_batch_order_and_diagnose():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg._factor_cache = OrderedDict()
+    rsg.factor_scorer = FactorScorerImpl(rsg)
     def stub_generate_signal(f1, f4, fd, *a, **k):
         rsg._diagnostic = {"id": f1["id"]}
         return {"id": f1["id"]}

--- a/tests/test_signal_generator_misc.py
+++ b/tests/test_signal_generator_misc.py
@@ -1,13 +1,16 @@
 import pytest
 import numpy as np
-from collections import deque
+from collections import deque, OrderedDict
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.market_phase import get_market_phase
+from quant_trade.signal.factor_scorer import FactorScorerImpl
 
 
 def make_rsg():
     r = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    r._factor_cache = OrderedDict()
+    r.factor_scorer = FactorScorerImpl(r)
     r._prev_raw = {p: None for p in ("1h", "4h", "d1")}
     r.sentiment_alpha = 0.5
     r.cap_positive_scale = 0.4

--- a/tests/test_standardized_logic.py
+++ b/tests/test_standardized_logic.py
@@ -6,7 +6,7 @@ def test_range_filter_respects_vol_breakout_zero():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.5, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)
@@ -43,7 +43,7 @@ def test_break_support_triggers_range_when_standardized():
     rsg = make_dummy_rsg()
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.predictor.get_ai_score = lambda f, up, down: 0
-    rsg.get_factor_scores = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
+    rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
     rsg.compute_tp_sl = lambda *a, **k: (0, 0)

--- a/tests/test_vectorized_funcs.py
+++ b/tests/test_vectorized_funcs.py
@@ -40,7 +40,7 @@ def test_calc_factor_scores_vectorized_matches_loop():
         'funding': np.array([0.1, 0.1]),
     } for p in ('1h', '4h', 'd1')}
 
-    vec = rsg.calc_factor_scores_vectorized(ai, fs, rsg.base_weights)
+    vec = rsg.factor_scorer.calc_factor_scores_vectorized(ai, fs, rsg.base_weights)
 
     expected = {}
     for p in ('1h', '4h', 'd1'):


### PR DESCRIPTION
## Summary
- extract factor scoring logic into new `FactorScorerImpl`
- delegate factor-related methods in `RobustSignalGenerator` to `FactorScorerImpl`
- update calls to use the new scorer

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6899c33d6a90832aab7c0f9d7ed7e9e5