### PR TITLE
refactor: extract risk filter logic

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -38,6 +38,7 @@ from .utils import (
 from .voting_model import VotingModel, load_cached_model
 from .factor_scorer import FactorScorerImpl
 from .fusion_rule import FusionRuleBased
+from .risk_filters import RiskFiltersImpl
 
 __all__ = [
     "SignalThresholdParams",
@@ -73,4 +74,5 @@ __all__ = [
     "load_cached_model",
     "FactorScorerImpl",
     "FusionRuleBased",
+    "RiskFiltersImpl",
 ]

--- a/quant_trade/signal/fusion_rule.py
+++ b/quant_trade/signal/fusion_rule.py
@@ -114,46 +114,6 @@ class FusionRuleBased:
         factor *= max(0.6, 1 - dd)
         return factor
 
-    def apply_crowding_protection(
-        self,
-        fused_score: float,
-        *,
-        base_th: float,
-        all_scores_list: list | None,
-        oi_chg: float | None,
-        cache: dict,
-        vol_pred: float | None,
-        oi_overheat: bool,
-        symbol: str | None,
-    ) -> tuple[float, float, float | None]:
-        """Compute crowding factor and adjust ``fused_score`` accordingly."""
-        th_oi = cache.get("th_oi")
-        if th_oi is None and oi_chg is not None:
-            th_oi = self.core.get_dynamic_oi_threshold(pred_vol=vol_pred)
-            cache["th_oi"] = th_oi
-
-        crowding_factor = 1.0
-        if not oi_overheat and all_scores_list is not None:
-            factor = self.crowding_protection(all_scores_list, fused_score, base_th)
-            fused_score *= factor
-            crowding_factor *= factor
-
-        if th_oi is not None and oi_chg is not None:
-            oi_crowd = abs(oi_chg) / max(th_oi, 1e-6)
-            mult = 1 - min(0.5, oi_crowd * 0.5)
-            if mult < 1:
-                logging.debug(
-                    "oi change %.4f threshold %.3f -> crowding mult %.3f for %s",
-                    oi_chg,
-                    th_oi,
-                    mult,
-                    symbol,
-                )
-                fused_score *= mult
-                crowding_factor *= mult
-
-        return fused_score, crowding_factor, th_oi
-
     def fuse(
         self,
         scores: dict,

--- a/quant_trade/signal/risk_filters.py
+++ b/quant_trade/signal/risk_filters.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+"""Risk filter utilities extracted from :mod:`core`."""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Sequence
+
+import numpy as np
+
+from ..constants import ZeroReason
+from .thresholding_dynamic import ThresholdingDynamic, compute_dynamic_threshold
+from .utils import risk_budget_threshold
+
+
+class RiskFiltersImpl:
+    """封装风险相关过滤逻辑的实现类"""
+
+    def __init__(self, core) -> None:
+        """Parameters
+        ----------
+        core : RobustSignalGenerator
+            主体对象实例, 用于访问共享的方法与属性
+        """
+        self.core = core
+
+    # ------------------------------------------------------------------
+    # OI 过热保护
+    # ------------------------------------------------------------------
+    def apply_oi_overheat_protection(self, fused_score, oi_chg, th_oi):
+        """根据 OI 变化调整得分, 并返回是否过热标记"""
+        if th_oi is None or abs(oi_chg) < th_oi:
+            return fused_score * (1 + 0.03 * oi_chg), False
+
+        logging.info("OI overheat detected: %.4f", oi_chg)
+        return fused_score * self.core.oi_scale, True
+
+    # ------------------------------------------------------------------
+    # 拥挤度保护
+    # ------------------------------------------------------------------
+    def apply_crowding_protection(
+        self,
+        fused_score: float,
+        *,
+        base_th: float,
+        all_scores_list: Sequence[float] | None,
+        oi_chg: float | None,
+        cache: dict,
+        vol_pred: float | None,
+        oi_overheat: bool,
+        symbol: str | None,
+    ) -> tuple[float, float, float | None]:
+        """计算拥挤度因子并调整 ``fused_score``"""
+        th_oi = cache.get("th_oi")
+        if th_oi is None and oi_chg is not None:
+            th_oi = self.core.get_dynamic_oi_threshold(pred_vol=vol_pred)
+            cache["th_oi"] = th_oi
+
+        crowding_factor = 1.0
+        if not oi_overheat and all_scores_list is not None:
+            factor = self.core.fusion_rule.crowding_protection(
+                all_scores_list, fused_score, base_th
+            )
+            fused_score *= factor
+            crowding_factor *= factor
+
+        if th_oi is not None and oi_chg is not None:
+            oi_crowd = abs(oi_chg) / max(th_oi, 1e-6)
+            mult = 1 - min(0.5, oi_crowd * 0.5)
+            if mult < 1:
+                logging.debug(
+                    "oi change %.4f threshold %.3f -> crowding mult %.3f for %s",
+                    oi_chg,
+                    th_oi,
+                    mult,
+                    symbol,
+                )
+                fused_score *= mult
+                crowding_factor *= mult
+
+        return fused_score, crowding_factor, th_oi
+
+    # ------------------------------------------------------------------
+    # 综合风险过滤
+    # ------------------------------------------------------------------
+    def apply_risk_filters(
+        self,
+        fused_score: float,
+        logic_score: float,
+        env_score: float,
+        std_1h: dict,
+        std_4h: dict,
+        std_d1: dict,
+        raw_f1h: dict,
+        raw_f4h: dict,
+        raw_fd1: dict,
+        vol_preds: dict,
+        open_interest: dict | None,
+        all_scores_list: list | None,
+        rev_dir: int,
+        cache: dict,
+        global_metrics: dict | None,
+        symbol: str | None,
+    ):
+        """执行风险限制与拥挤度检查"""
+        core = self.core
+        penalties: list[str] = []
+        if not core.risk_filters_enabled and not core.dynamic_threshold_enabled:
+            return {
+                "fused_score": fused_score,
+                "risk_score": 0.0,
+                "crowding_factor": 1.0,
+                "base_th": core.signal_params.base_th,
+            }
+        atr_1h = raw_f1h.get("atr_pct_1h", 0) if raw_f1h else 0
+        adx_1h = raw_f1h.get("adx_1h", 0) if raw_f1h else 0
+        funding_1h = raw_f1h.get("funding_rate_1h", 0) if raw_f1h else 0
+
+        atr_4h = raw_f4h.get("atr_pct_4h") if raw_f4h else None
+        adx_4h = raw_f4h.get("adx_4h") if raw_f4h else None
+        atr_d1 = raw_fd1.get("atr_pct_d1") if raw_fd1 else None
+        adx_d1 = raw_fd1.get("adx_d1") if raw_fd1 else None
+
+        vix_p = None
+        if global_metrics is not None:
+            vix_p = global_metrics.get("vix_proxy")
+        if vix_p is None and open_interest is not None:
+            vix_p = open_interest.get("vix_proxy")
+
+        bb_chg = raw_f1h.get("bb_width_chg_1h") if raw_f1h else None
+        channel_pos = raw_f1h.get("channel_pos_1h") if raw_f1h else None
+        regime = core.detect_market_regime(
+            adx_1h,
+            adx_4h or 0,
+            adx_d1 or 0,
+            bb_chg,
+            channel_pos,
+        )
+        rsi_d1 = std_d1.get("rsi_d1", 50)
+        hist_d1 = cache.get("_raw_history", {}).get("d1", [])
+        pairs = [(h.get("rsi_d1"), h.get("vol_ma_ratio_d1")) for h in hist_d1]
+        rsi_hist = [p[0] for p in pairs if p[0] is not None and p[1] is not None]
+        vol_hist = [p[1] for p in pairs if p[0] is not None and p[1] is not None]
+        lower, _ = ThresholdingDynamic.adaptive_rsi_threshold(
+            rsi_hist, vol_hist, core.rsi_k
+        )
+        if std_d1.get("break_support_d1", 0) > 0 and rsi_d1 < lower:
+            regime = "range"
+            rev_dir = 1
+        cfg_th = core.signal_threshold_cfg
+        params = core.signal_params
+        cfg_base = cfg_th.get("base_th", params.base_th)
+        if core.dynamic_threshold_enabled:
+            dyn_base = compute_dynamic_threshold(
+                cache["history_scores"], params.window, params.dynamic_quantile
+            )
+            base_input = dyn_base if dyn_base is not None else cfg_base
+            base_th, rev_boost = core.thresholding.base(
+                atr_1h,
+                adx_1h,
+                funding_1h,
+                atr_4h=atr_4h,
+                adx_4h=adx_4h,
+                atr_d1=atr_d1,
+                adx_d1=adx_d1,
+                bb_width_chg=bb_chg,
+                channel_pos=channel_pos,
+                pred_vol=vol_preds.get("1h"),
+                pred_vol_4h=vol_preds.get("4h"),
+                pred_vol_d1=vol_preds.get("d1"),
+                vix_proxy=vix_p,
+                regime=regime,
+                base=base_input,
+                reversal=bool(rev_dir),
+                history_scores=cache["history_scores"],
+            )
+        else:
+            base_th = cfg_base
+            rev_boost = cfg_th.get("rev_boost", params.rev_boost)
+        base_th *= getattr(core, "phase_th_mult", 1.0)
+        if rev_dir != 0:
+            fused_score += rev_boost * rev_dir
+            core._cooldown = 0
+
+        if not core.risk_filters_enabled:
+            return {
+                "fused_score": fused_score,
+                "risk_score": 0.0,
+                "crowding_factor": 1.0,
+                "base_th": base_th,
+            }
+
+        funding_conflicts = 0
+        for p, raw_f in [("1h", raw_f1h), ("4h", raw_f4h), ("d1", raw_fd1)]:
+            if raw_f is None:
+                continue
+            f_rate = raw_f.get(f"funding_rate_{p}", 0)
+            if abs(f_rate) > 0.0005 and np.sign(f_rate) * np.sign(fused_score) < 0:
+                penalty = min(abs(f_rate) * 20, 0.20)
+                fused_score *= 1 - penalty
+                funding_conflicts += 1
+        if funding_conflicts >= core.veto_conflict_count:
+            if core.filter_penalty_mode:
+                fused_score *= core.penalty_factor
+                penalties.append(ZeroReason.FUNDING_PENALTY.value)
+            else:
+                return None
+
+        fused_score, crowding_factor, th_oi = self.apply_crowding_protection(
+            fused_score,
+            base_th=base_th,
+            all_scores_list=all_scores_list,
+            oi_chg=cache.get("oi_chg"),
+            cache=cache,
+            vol_pred=vol_preds.get("1h"),
+            oi_overheat=cache.get("oi_overheat", False),
+            symbol=symbol,
+        )
+        risk_score = core.risk_manager.calc_risk(
+            env_score,
+            pred_vol=vol_preds.get("1h"),
+            oi_change=open_interest.get("oi_chg") if open_interest else None,
+        )
+
+        fused_score *= 1 - core.risk_adjust_factor * risk_score
+        # 根据历史波动或换手率动态调整风控阈值
+        with core._lock:
+            atr_hist = [
+                r.get("atr_pct_1h")
+                for r in cache.get("_raw_history", {}).get("1h", [])
+                if r.get("atr_pct_1h") is not None
+            ]
+            oi_hist = list(cache.get("oi_change_history", []))
+        hist = [abs(v) for v in atr_hist if v is not None]
+        if not hist:
+            hist = [abs(v) for v in oi_hist if v is not None]
+        dyn_risk_th = (
+            risk_budget_threshold(hist, quantile=core.signal_params.quantile)
+            if hist
+            else float("nan")
+        )
+        risk_th = core.risk_adjust_threshold
+        if risk_th is None:
+            with core._lock:
+                hist_scores = list(cache.get("history_scores", []))
+            risk_th = risk_budget_threshold(
+                hist_scores, quantile=core.risk_th_quantile
+            )
+            if math.isnan(risk_th):
+                risk_th = 0.0
+        if math.isnan(dyn_risk_th):
+            logging.warning(
+                "历史数据不足，继续使用固定风险阈值；atr_hist=%s，oi_hist=%s",
+                atr_hist,
+                oi_hist,
+            )
+        else:
+            risk_th = max(risk_th, dyn_risk_th)
+
+        if abs(fused_score) < risk_th:
+            return None
+
+        if (
+            risk_score > core.risk_score_limit
+            or crowding_factor < 0
+            or crowding_factor > core.crowding_limit
+        ):
+            if core.filter_penalty_mode:
+                fused_score *= core.penalty_factor
+                penalties.append(ZeroReason.RISK_PENALTY.value)
+            else:
+                return None
+
+        with core._lock:
+            cache["history_scores"].append(fused_score)
+            core.all_scores_list.append(fused_score)
+
+        return {
+            "fused_score": fused_score,
+            "risk_score": risk_score,
+            "crowding_factor": crowding_factor,
+            "crowding_adjusted": True,
+            "risk_th": risk_th,
+            "base_th": base_th,
+            "rev_boost": rev_boost,
+            "regime": regime,
+            "rev_dir": rev_dir,
+            "funding_conflicts": funding_conflicts,
+            "details": {"penalties": penalties} if penalties else {},
+        }

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -6,6 +6,7 @@ from quant_trade.signal.thresholding_dynamic import ThresholdingDynamic
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_dummy_rsg():
@@ -77,8 +78,8 @@ def make_dummy_rsg():
     rsg.fusion_rule = FusionRuleBased(rsg)
     rsg.consensus_check = rsg.fusion_rule.consensus_check
     rsg.crowding_protection = rsg.fusion_rule.crowding_protection
-    rsg.apply_crowding_protection = rsg.fusion_rule.apply_crowding_protection
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
     rsg.thresholding = ThresholdingDynamic(rsg)
+    rsg.risk_filters = RiskFiltersImpl(rsg)
     return rsg

--- a/tests/test_dynamic_min.py
+++ b/tests/test_dynamic_min.py
@@ -80,7 +80,7 @@ def test_dyn_th_active_when_filters_off():
     rsg.dynamic_threshold = lambda *a, **k: (0.2, 0.0)
     rsg.detect_market_regime = lambda *a, **k: "range"
     cache = {"history_scores": rsg.history_scores, "_raw_history": {"1h": []}, "oi_change_history": []}
-    res = rsg.apply_risk_filters(
+    res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.1,
         logic_score=0.1,
         env_score=0.0,

--- a/tests/test_oi_reversal_crowding.py
+++ b/tests/test_oi_reversal_crowding.py
@@ -7,10 +7,10 @@ from quant_trade.tests.test_utils import make_dummy_rsg
 def test_apply_oi_overheat_protection():
     rsg = make_dummy_rsg()
     rsg.oi_scale = 0.7
-    val, flag = rsg.apply_oi_overheat_protection(1.0, 0.1, 0.3)
+    val, flag = rsg.risk_filters.apply_oi_overheat_protection(1.0, 0.1, 0.3)
     assert flag is False
     assert val == pytest.approx(1.0 * (1 + 0.03 * 0.1))
-    val2, flag2 = rsg.apply_oi_overheat_protection(1.0, 0.4, 0.3)
+    val2, flag2 = rsg.risk_filters.apply_oi_overheat_protection(1.0, 0.4, 0.3)
     assert flag2 is True
     assert val2 == pytest.approx(1.0 * 0.7)
 

--- a/tests/test_penalty_mode.py
+++ b/tests/test_penalty_mode.py
@@ -25,7 +25,7 @@ def test_penalty_on_risk_filters():
     rsg.risk_manager.calc_risk = lambda *a, **k: 1.0
     cache = make_cache()
     raw_f1h = {"funding_rate_1h": -0.001}
-    res = rsg.apply_risk_filters(
+    res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.5,
         logic_score=0.5,
         env_score=0.0,

--- a/tests/test_range_guard.py
+++ b/tests/test_range_guard.py
@@ -4,6 +4,7 @@ from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_rsg():
@@ -54,9 +55,9 @@ def make_rsg():
     r.fusion_rule = FusionRuleBased(r)
     r.consensus_check = r.fusion_rule.consensus_check
     r.crowding_protection = r.fusion_rule.crowding_protection
-    r.apply_crowding_protection = r.fusion_rule.apply_crowding_protection
     r.fuse = r.fusion_rule.fuse
     r.fuse_multi_cycle = r.fusion_rule.fuse
+    r.risk_filters = RiskFiltersImpl(r)
     return r
 
 

--- a/tests/test_reversal.py
+++ b/tests/test_reversal.py
@@ -6,6 +6,7 @@ from quant_trade.robust_signal_generator import RobustSignalGenerator, smooth_sc
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_rsg():
@@ -75,9 +76,9 @@ def make_rsg():
     rsg.fusion_rule = FusionRuleBased(rsg)
     rsg.consensus_check = rsg.fusion_rule.consensus_check
     rsg.crowding_protection = rsg.fusion_rule.crowding_protection
-    rsg.apply_crowding_protection = rsg.fusion_rule.apply_crowding_protection
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
+    rsg.risk_filters = RiskFiltersImpl(rsg)
     return rsg
 
 

--- a/tests/test_risk_budget_threshold.py
+++ b/tests/test_risk_budget_threshold.py
@@ -26,7 +26,7 @@ def test_risk_budget_threshold_in_filter():
         "oi_change_history": rsg.oi_change_history,
         "_raw_history": {"1h": deque(maxlen=4)},
     }
-    res = rsg.apply_risk_filters(
+    res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.04,
         logic_score=0.04,
         env_score=0.0,
@@ -46,7 +46,7 @@ def test_risk_budget_threshold_in_filter():
     )
     assert res is None
 
-    res2 = rsg.apply_risk_filters(
+    res2 = rsg.risk_filters.apply_risk_filters(
         fused_score=0.06,
         logic_score=0.06,
         env_score=0.0,
@@ -79,7 +79,7 @@ def test_history_quantile_threshold():
         "_raw_history": {"1h": deque(maxlen=4)},
     }
 
-    res = rsg.apply_risk_filters(
+    res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.02,
         logic_score=0.02,
         env_score=0.0,
@@ -100,7 +100,7 @@ def test_history_quantile_threshold():
 
     assert res is None
 
-    res2 = rsg.apply_risk_filters(
+    res2 = rsg.risk_filters.apply_risk_filters(
         fused_score=0.06,
         logic_score=0.06,
         env_score=0.0,

--- a/tests/test_risk_threshold_warning.py
+++ b/tests/test_risk_threshold_warning.py
@@ -18,7 +18,7 @@ def test_nan_dynamic_risk_threshold(caplog):
         "_raw_history": {"1h": deque(maxlen=4)},
     }
     with caplog.at_level(logging.WARNING):
-        res = rsg.apply_risk_filters(
+        res = rsg.risk_filters.apply_risk_filters(
             fused_score=0.04,
             logic_score=0.04,
             env_score=0.0,

--- a/tests/test_rsg.py
+++ b/tests/test_rsg.py
@@ -7,6 +7,7 @@ from quant_trade.robust_signal_generator import RobustSignalGenerator, DynamicTh
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_rsg():
@@ -70,9 +71,9 @@ def make_rsg():
     rsg.fusion_rule = FusionRuleBased(rsg)
     rsg.consensus_check = rsg.fusion_rule.consensus_check
     rsg.crowding_protection = rsg.fusion_rule.crowding_protection
-    rsg.apply_crowding_protection = rsg.fusion_rule.apply_crowding_protection
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
+    rsg.risk_filters = RiskFiltersImpl(rsg)
     return rsg
 
 

--- a/tests/test_scoring_layers.py
+++ b/tests/test_scoring_layers.py
@@ -5,6 +5,7 @@ from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_simple_rsg():
@@ -46,9 +47,9 @@ def make_simple_rsg():
     rsg.fusion_rule = FusionRuleBased(rsg)
     rsg.consensus_check = rsg.fusion_rule.consensus_check
     rsg.crowding_protection = rsg.fusion_rule.crowding_protection
-    rsg.apply_crowding_protection = rsg.fusion_rule.apply_crowding_protection
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
+    rsg.risk_filters = RiskFiltersImpl(rsg)
     return rsg
 
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -10,6 +10,7 @@ from quant_trade.robust_signal_generator import (
 from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
+from quant_trade.signal.risk_filters import RiskFiltersImpl
 
 
 def make_rsg():
@@ -60,9 +61,9 @@ def make_rsg():
     rsg.fusion_rule = FusionRuleBased(rsg)
     rsg.consensus_check = rsg.fusion_rule.consensus_check
     rsg.crowding_protection = rsg.fusion_rule.crowding_protection
-    rsg.apply_crowding_protection = rsg.fusion_rule.apply_crowding_protection
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
+    rsg.risk_filters = RiskFiltersImpl(rsg)
     return rsg
 
 


### PR DESCRIPTION
## Summary
- move risk filter logic into new `RiskFiltersImpl`
- adjust core to use dedicated risk filter helper
- update tests for new risk filter interface

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6899d7094608832abeba203fa26e6f80