### PR TITLE
refactor: extract position sizing logic

### DIFF
--- a/quant_trade/signal/position_sizer.py
+++ b/quant_trade/signal/position_sizer.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import math
+from typing import Tuple, List
+
+import numpy as np
+
+from ..constants import ZeroReason
+from .utils import sigmoid
+from quant_trade.utils import get_cfg_value
+
+
+class PositionSizerImpl:
+    """仓位管理相关逻辑实现"""
+
+    def __init__(self, rsg):
+        self.rsg = rsg
+
+    def compute_exit_multiplier(self, vote: float, prev_vote: float, last_signal: int) -> float:
+        """根据票数变化决定半退出或全平仓位系数"""
+        with self.rsg._lock:
+            exit_lag = self.rsg._exit_lag
+
+        exit_mult = 1.0
+        vote_sign = np.sign(vote)
+        prev_sign = np.sign(prev_vote)
+        if last_signal == 1:
+            if vote_sign == 1 and prev_vote > vote:
+                exit_mult = 0.5
+                exit_lag = 0
+            elif vote_sign <= 0 and prev_sign > 0:
+                exit_lag += 1
+                exit_mult = 0.0 if exit_lag >= self.rsg.exit_lag_bars else 0.5
+            else:
+                exit_lag = 0
+        elif last_signal == -1:
+            if vote_sign == -1 and prev_vote < vote:
+                exit_mult = 0.5
+                exit_lag = 0
+            elif vote_sign >= 0 and prev_sign < 0:
+                exit_lag += 1
+                exit_mult = 0.0 if exit_lag >= self.rsg.exit_lag_bars else 0.5
+            else:
+                exit_lag = 0
+        else:
+            exit_lag = 0
+
+        with self.rsg._lock:
+            self.rsg._exit_lag = exit_lag
+
+        return exit_mult
+
+    def _apply_risk_adjustment(self, pos_size: float, risk_score: float) -> float:
+        """根据风险评分调整仓位大小"""
+        risk_factor = math.exp(-self.rsg.risk_scale * risk_score)
+        return pos_size * risk_factor
+
+    def _apply_low_volume_penalty(
+        self,
+        pos_size: float,
+        *,
+        regime: str,
+        vol_ratio: float | None,
+        fused_score: float,
+        base_th: float,
+        consensus_all: bool,
+    ) -> Tuple[float, bool]:
+        """在低成交量环境下惩罚仓位, 返回是否触发标记"""
+        low_vol_flag = (
+            regime == "range"
+            and vol_ratio is not None
+            and vol_ratio < self.rsg.low_vol_ratio
+            and abs(fused_score) < base_th + 0.02
+            and not consensus_all
+        )
+        if low_vol_flag:
+            pos_size *= 0.5
+        return pos_size, low_vol_flag
+
+    def _apply_vol_prediction_adjustment(self, pos_size: float, vol_p: float | None) -> float:
+        """根据预测波动率对仓位进行修正"""
+        if vol_p is not None:
+            pos_size *= max(0.4, 1 - min(0.6, vol_p))
+        return pos_size
+
+    def _adjust_min_pos_vol(self, min_pos: float, atr: float | None, vol_p: float | None) -> float:
+        """根据历史 ATR 或预测波动率调节仓位下限"""
+        vol_ref = 0.0
+        if vol_p is not None and np.isfinite(vol_p):
+            vol_ref = abs(vol_p)
+        elif atr is not None and np.isfinite(atr):
+            vol_ref = abs(atr)
+        return min_pos * (1 + self.rsg.min_pos_vol_scale * vol_ref)
+
+    def compute_tp_sl(
+        self,
+        price,
+        atr,
+        direction,
+        tp_mult: float = 1.5,
+        sl_mult: float = 1.0,
+        *,
+        rise_pred: float | None = None,
+        drawdown_pred: float | None = None,
+        regime: str | None = None,
+    ):
+        """计算止盈止损价格，可根据模型预测值微调"""
+        if direction == 0:
+            return None, None
+        if price is None or not np.isfinite(price):
+            return None, None
+        if price <= 0:
+            return None, None
+        if atr is None or not np.isfinite(atr):
+            return None, None
+        if atr == 0:
+            atr = 0.005 * price
+
+        cfg = getattr(self.rsg, "cfg", {})
+        max_sl_pct = get_cfg_value(cfg, "max_stop_loss_pct", 0.05)
+
+        if rise_pred is None:
+            rise_pred = 0.0
+        if drawdown_pred is None:
+            drawdown_pred = 0.0
+
+        if direction == 1:
+            max_sl = price * (1 - max_sl_pct)
+            tp0 = price * (1 + min(rise_pred, 0.10))
+            sl0 = price * (1 + max(drawdown_pred, -max_sl_pct))
+            tp = max(tp0, price * 1.02)
+            sl = min(sl0, max_sl)
+        else:
+            max_sl = price * (1 + max_sl_pct)
+            tp0 = price * (1 - min(rise_pred, 0.10))
+            sl0 = price * (1 - max(drawdown_pred, -max_sl_pct))
+            tp = min(tp0, price * 0.98)
+            sl = max(sl0, max_sl)
+
+        return float(tp), float(sl)
+
+    def _determine_direction(
+        self,
+        grad_dir: float,
+        regime: str,
+        fs: dict,
+        st_dir: int,
+        vol_breakout_val: float | None,
+        conf_vote: float,
+        weak_vote: bool,
+        fused_score: float,
+        base_th: float,
+        raw_f1h: dict | None,
+        std_1h: dict,
+        ts,
+        symbol,
+    ) -> int:
+        """Determine final trade direction."""
+
+        if not self.rsg.direction_filters_enabled:
+            return 0 if grad_dir == 0 else int(np.sign(grad_dir))
+
+        direction = 0 if grad_dir == 0 else int(np.sign(grad_dir))
+        if weak_vote:
+            direction = 0
+
+        if regime == "range":
+            atr_v = (raw_f1h or std_1h).get("atr_pct_1h")
+            bb_w = (raw_f1h or std_1h).get("bb_width_1h")
+            low_vol = False
+            if atr_v is not None and atr_v < 0.005:
+                low_vol = True
+            if bb_w is not None and bb_w < 0.01:
+                low_vol = True
+            if low_vol:
+                direction = 0
+            elif vol_breakout_val is None or vol_breakout_val <= 0 or conf_vote < 0.15:
+                direction = 0
+
+        if self.rsg._cooldown > 0:
+            self.rsg._cooldown -= 1
+
+        if self.rsg._last_signal != 0 and direction != 0 and direction != self.rsg._last_signal:
+            flip_th = max(base_th, self.rsg.flip_coeff * abs(self.rsg._last_score))
+            if abs(fused_score) < flip_th or self.rsg._cooldown > 0:
+                direction = self.rsg._last_signal
+            else:
+                self.rsg._cooldown = 2
+
+        align_count = 0
+        if direction != 0:
+            for p in ("1h", "4h", "d1"):
+                if np.sign(fs[p]["trend"]) == direction:
+                    align_count += 1
+            if st_dir != 0 and st_dir == direction:
+                align_count += 1
+            min_align = self.rsg.min_trend_align if regime == "trend" else max(
+                self.rsg.min_trend_align - 1, 0
+            )
+            if align_count < min_align:
+                direction = 0
+
+        return direction
+
+    def _apply_position_filters(
+        self,
+        pos_size: float,
+        direction: int,
+        *,
+        weak_vote: bool,
+        funding_conflicts: int,
+        oi_overheat: bool,
+        risk_score: float,
+        logic_score: float,
+        base_th: float,
+        conflict_filter_triggered: bool,
+        zero_reason: str | None,
+    ) -> Tuple[float, int, str | None, List[str]]:
+        """Apply filters to position size and direction."""
+
+        penalties: List[str] = []
+
+        if not self.rsg.direction_filters_enabled:
+            return pos_size, direction, zero_reason, penalties
+
+        if weak_vote:
+            if self.rsg.filter_penalty_mode:
+                pos_size *= self.rsg.penalty_factor
+                penalties.append(ZeroReason.VOTE_PENALTY.value)
+                zero_reason = None
+            else:
+                direction = 0
+                pos_size = 0.0
+                zero_reason = zero_reason or ZeroReason.VOTE_FILTER.value
+
+        if funding_conflicts > self.rsg.veto_level:
+            if self.rsg.filter_penalty_mode:
+                pos_size *= self.rsg.penalty_factor
+                penalties.append(ZeroReason.FUNDING_PENALTY.value)
+                zero_reason = None
+            else:
+                direction = 0
+                pos_size = 0.0
+                zero_reason = zero_reason or ZeroReason.FUNDING_CONFLICT.value
+
+        if oi_overheat:
+            pos_size *= 0.5
+
+        pos_map = base_th * 2.0
+        if risk_score > 1 or logic_score < -0.3:
+            pos_map = min(pos_map, 0.5)
+        pos_size = min(pos_size, pos_map)
+
+        if conflict_filter_triggered:
+            if self.rsg.filter_penalty_mode:
+                pos_size *= self.rsg.penalty_factor
+                penalties.append(ZeroReason.CONFLICT_PENALTY.value)
+                zero_reason = None
+            else:
+                pos_size = 0.0
+                direction = 0
+                zero_reason = zero_reason or ZeroReason.CONFLICT_FILTER.value
+
+        return pos_size, direction, zero_reason, penalties
+
+    def decide(
+        self,
+        *,
+        grad_dir: float,
+        base_coeff: float,
+        confidence_factor: float,
+        vol_ratio: float | None,
+        fused_score: float,
+        base_th: float,
+        regime: str,
+        vol_p: float | None,
+        atr: float | None,
+        risk_score: float,
+        crowding_factor: float,
+        cfg_th_sig: dict,
+        direction: int,
+        exit_mult: float,
+        consensus_all: bool = False,
+    ) -> Tuple[float, int, float, str | None]:
+        """Calculate final position size and tier."""
+
+        tier = base_coeff * abs(grad_dir)
+        base_size = tier
+
+        zero_reason: str | None = None
+        low_vol_flag = False
+
+        pos_size = base_size * sigmoid(confidence_factor)
+        pos_size = self._apply_risk_adjustment(pos_size, risk_score)
+        pos_size *= exit_mult
+        pos_size = min(pos_size, self.rsg.max_position)
+        pos_size *= crowding_factor
+        if direction == 0:
+            pos_size = 0.0
+            zero_reason = ZeroReason.NO_DIRECTION.value
+
+        pos_size, low_vol_flag = self._apply_low_volume_penalty(
+            pos_size,
+            regime=regime,
+            vol_ratio=vol_ratio,
+            fused_score=fused_score,
+            base_th=base_th,
+            consensus_all=consensus_all,
+        )
+
+        pos_size = self._apply_vol_prediction_adjustment(pos_size, vol_p)
+
+        min_pos = cfg_th_sig.get("min_pos", self.rsg.signal_params.min_pos)
+        min_pos = self._adjust_min_pos_vol(min_pos, atr, vol_p)
+        dynamic_min = min_pos * math.exp(self.rsg.risk_scale * risk_score)
+        if self.rsg.risk_filters_enabled and pos_size < dynamic_min:
+            pos_size = min(max(pos_size, dynamic_min), self.rsg.max_position)
+            zero_reason = ZeroReason.MIN_POS.value
+
+        return pos_size, direction, tier, zero_reason

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -7,6 +7,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_dummy_rsg():
@@ -82,4 +83,5 @@ def make_dummy_rsg():
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
     rsg.thresholding = ThresholdingDynamic(rsg)
     rsg.risk_filters = RiskFiltersImpl(rsg)
+    rsg.position_sizer = PositionSizerImpl(rsg)
     return rsg

--- a/tests/test_dynamic_min.py
+++ b/tests/test_dynamic_min.py
@@ -23,18 +23,18 @@ def test_dynamic_min_risk_scaling():
         exit_mult=1.0,
         consensus_all=False,
     )
-    pos_normal, direction_normal, _, zero_reason_normal = rsg.compute_position_size(**params)
+    pos_normal, direction_normal, _, zero_reason_normal = rsg.position_sizer.decide(**params)
     assert pos_normal > 0
     assert zero_reason_normal is None
 
     params["risk_score"] = 2.0
-    pos_high, direction_high, _, zero_reason_high = rsg.compute_position_size(**params)
+    pos_high, direction_high, _, zero_reason_high = rsg.position_sizer.decide(**params)
     assert pos_high > 0
     assert direction_high == 1
     assert zero_reason_high == ZeroReason.MIN_POS.value
 
     rsg.risk_filters_enabled = False
-    pos_off, direction_off, _, zero_reason_off = rsg.compute_position_size(**params)
+    pos_off, direction_off, _, zero_reason_off = rsg.position_sizer.decide(**params)
     assert pos_off > 0
     assert direction_off != 0
     assert zero_reason_off is None
@@ -61,13 +61,13 @@ def test_min_pos_vol_scaling():
         exit_mult=1.0,
         consensus_all=False,
     )
-    pos_high, _, _, reason_high = rsg.compute_position_size(**params)
+    pos_high, _, _, reason_high = rsg.position_sizer.decide(**params)
     assert pos_high > 0
     assert reason_high == ZeroReason.MIN_POS.value
 
     rsg.min_pos_vol_scale = 0.0
     params["atr"] = 0.0
-    pos_normal, _, _, reason_normal = rsg.compute_position_size(**params)
+    pos_normal, _, _, reason_normal = rsg.position_sizer.decide(**params)
     assert pos_normal > 0
     assert pos_high >= pos_normal
     assert reason_normal is None

--- a/tests/test_fe_rsg_integration.py
+++ b/tests/test_fe_rsg_integration.py
@@ -42,7 +42,7 @@ def test_feature_engineer_to_rsg_signal(monkeypatch):
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: 0.2
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg._precheck_and_direction = lambda *a, **k: ({'signal': 1, 'score': 0.2, 'position_size': 0.1, 'take_profit': None, 'stop_loss': None, 'details': {}}, 0.2, 1)
     rsg.models = {'1h': {'up': None, 'down': None}, '4h': {'up': None, 'down': None}, 'd1': {'up': None, 'down': None}}
 

--- a/tests/test_low_vol_ratio.py
+++ b/tests/test_low_vol_ratio.py
@@ -24,14 +24,14 @@ def test_low_vol_ratio_config():
     )
 
     rsg.low_vol_ratio = 0.4
-    pos1, _, _, _ = rsg.compute_position_size(vol_ratio=0.35, **base_params)
+    pos1, _, _, _ = rsg.position_sizer.decide(vol_ratio=0.35, **base_params)
 
     base_params_no_risk = base_params.copy()
     base_params_no_risk["risk_score"] = 0.0
-    pos_no_risk, _, _, _ = rsg.compute_position_size(vol_ratio=0.35, **base_params_no_risk)
+    pos_no_risk, _, _, _ = rsg.position_sizer.decide(vol_ratio=0.35, **base_params_no_risk)
 
     rsg.low_vol_ratio = 0.2
-    pos2, _, _, _ = rsg.compute_position_size(vol_ratio=0.35, **base_params)
+    pos2, _, _, _ = rsg.position_sizer.decide(vol_ratio=0.35, **base_params)
 
     assert pos1 == pytest.approx(pos2 * 0.5)
     assert pos1 == pytest.approx(pos_no_risk * math.exp(-rsg.risk_scale * 0.5))
@@ -58,11 +58,11 @@ def test_low_vol_penalty_only_in_range():
     )
     rsg.low_vol_ratio = 0.4
     params_range = base | {"regime": "range"}
-    pos_range, _, _, _ = rsg.compute_position_size(**params_range)
+    pos_range, _, _, _ = rsg.position_sizer.decide(**params_range)
     params_trend = base | {"regime": "trend"}
-    pos_trend, _, _, _ = rsg.compute_position_size(**params_trend)
+    pos_trend, _, _, _ = rsg.position_sizer.decide(**params_trend)
     params_high = base | {"regime": "range", "vol_ratio": 0.6}
-    pos_high, _, _, _ = rsg.compute_position_size(**params_high)
+    pos_high, _, _, _ = rsg.position_sizer.decide(**params_high)
     assert pos_range == pytest.approx(pos_trend * 0.5)
     assert pos_high == pytest.approx(pos_trend)
 
@@ -86,8 +86,8 @@ def test_vol_prediction_adjustment():
         exit_mult=1.0,
         consensus_all=False,
     )
-    pos_none, _, _, _ = rsg.compute_position_size(vol_p=None, **base)
-    pos_half, _, _, _ = rsg.compute_position_size(vol_p=0.5, **base)
-    pos_floor, _, _, _ = rsg.compute_position_size(vol_p=0.9, **base)
+    pos_none, _, _, _ = rsg.position_sizer.decide(vol_p=None, **base)
+    pos_half, _, _, _ = rsg.position_sizer.decide(vol_p=0.5, **base)
+    pos_floor, _, _, _ = rsg.position_sizer.decide(vol_p=0.9, **base)
     assert pos_half == pytest.approx(pos_none * 0.5)
     assert pos_floor == pytest.approx(pos_none * 0.4)

--- a/tests/test_new_funcs.py
+++ b/tests/test_new_funcs.py
@@ -171,8 +171,8 @@ def test_ai_dir_eps_threshold_check():
 def test_compute_exit_multiplier():
     rsg = make_dummy_rsg()
     rsg._exit_lag = 0
-    assert rsg.compute_exit_multiplier(2, 5, 1) == 0.5
+    assert rsg.position_sizer.compute_exit_multiplier(2, 5, 1) == 0.5
     assert rsg._exit_lag == 0
-    val = rsg.compute_exit_multiplier(-1, 2, 1)
+    val = rsg.position_sizer.compute_exit_multiplier(-1, 2, 1)
     assert val == 0.0
     assert rsg._exit_lag == 1

--- a/tests/test_oi_reversal_crowding.py
+++ b/tests/test_oi_reversal_crowding.py
@@ -30,7 +30,7 @@ def test_detect_reversal_adjusts_threshold():
     rsg.predictor.get_ai_score = lambda *a, **k: 0
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: ai
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -64,10 +64,10 @@ def test_crowding_factor_reduces_position():
         exit_mult=1.0,
         consensus_all=False,
     )
-    full, _, _, _ = rsg.compute_position_size(crowding_factor=1.0, **params)
-    reduced, _, _, _ = rsg.compute_position_size(crowding_factor=0.5, **params)
+    full, _, _, _ = rsg.position_sizer.decide(crowding_factor=1.0, **params)
+    reduced, _, _, _ = rsg.position_sizer.decide(crowding_factor=0.5, **params)
     params_no_risk = params.copy()
     params_no_risk["risk_score"] = 0.0
-    base_full, _, _, _ = rsg.compute_position_size(crowding_factor=1.0, **params_no_risk)
+    base_full, _, _, _ = rsg.position_sizer.decide(crowding_factor=1.0, **params_no_risk)
     assert reduced == pytest.approx(full * 0.5)
     assert full == pytest.approx(base_full * math.exp(-rsg.risk_scale * 0.3))

--- a/tests/test_penalty_mode.py
+++ b/tests/test_penalty_mode.py
@@ -55,7 +55,7 @@ def test_position_penalty_mode():
     rsg.filter_penalty_mode = True
     rsg.penalty_factor = 0.5
     rsg.veto_level = 0.4
-    pos, direction, zr, p1 = rsg._apply_position_filters(
+    pos, direction, zr, p1 = rsg.position_sizer._apply_position_filters(
         0.2,
         1,
         weak_vote=True,
@@ -72,7 +72,7 @@ def test_position_penalty_mode():
     assert zr is None
     assert p1 == [ZeroReason.VOTE_PENALTY.value]
 
-    pos2, direction2, zr2, p2 = rsg._apply_position_filters(
+    pos2, direction2, zr2, p2 = rsg.position_sizer._apply_position_filters(
         0.2,
         1,
         weak_vote=False,

--- a/tests/test_range_guard.py
+++ b/tests/test_range_guard.py
@@ -5,6 +5,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_rsg():
@@ -58,6 +59,7 @@ def make_rsg():
     r.fuse = r.fusion_rule.fuse
     r.fuse_multi_cycle = r.fusion_rule.fuse
     r.risk_filters = RiskFiltersImpl(r)
+    r.position_sizer = PositionSizerImpl(r)
     return r
 
 
@@ -69,7 +71,7 @@ def test_range_guard():
     gen.combine_score = lambda ai, fs, weights=None: next(scores_seq)
     gen.factor_scorer.score = lambda f, p: {k: 0 for k in gen.base_weights if k != 'ai'}
     gen.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    gen.compute_tp_sl = lambda *a, **k: (0, 0)
+    gen.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     gen.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}

--- a/tests/test_range_strong_filter.py
+++ b/tests/test_range_strong_filter.py
@@ -9,7 +9,7 @@ def setup_rsg():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},

--- a/tests/test_reversal.py
+++ b/tests/test_reversal.py
@@ -7,6 +7,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_rsg():
@@ -68,7 +69,8 @@ def make_rsg():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.2, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer = PositionSizerImpl(rsg)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg._raw_history = {'1h': deque(maxlen=4), '4h': deque(maxlen=2), 'd1': deque(maxlen=2)}
     rsg._cooldown = 3
     rsg.min_trend_align = 1
@@ -133,7 +135,7 @@ def test_flip_requires_confirmation():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: -0.4
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}

--- a/tests/test_risk_budget.py
+++ b/tests/test_risk_budget.py
@@ -16,7 +16,7 @@ def test_risk_budget_caps_position():
     rsg.account = DummyAccount(1000)
     rsg.cfg['risk_budget_per_trade'] = 0.0005
     rsg.cfg['max_pos_pct'] = 1.0
-    rsg.compute_tp_sl = lambda price, atr, direction, **k: (price * 1.05, 95)
+    rsg.position_sizer.compute_tp_sl = lambda price, atr, direction, **k: (price * 1.05, 95)
     (
         risk_info,
         ai_scores,

--- a/tests/test_rsg.py
+++ b/tests/test_rsg.py
@@ -8,6 +8,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_rsg():
@@ -74,6 +75,7 @@ def make_rsg():
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
     rsg.risk_filters = RiskFiltersImpl(rsg)
+    rsg.position_sizer = PositionSizerImpl(rsg)
     return rsg
 
 
@@ -132,7 +134,7 @@ def test_dynamic_weight_handles_nan_history():
 
 def test_compute_tp_sl_fallback():
     rsg = make_rsg()
-    tp, sl = rsg.compute_tp_sl(100, 0, 1)
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 0, 1)
     assert tp is not None and sl is not None
 
 
@@ -143,7 +145,7 @@ def test_flip_threshold_allows_switch():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: -0.75
     rsg.dynamic_threshold = lambda *a, **k: (0.6, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None}, '4h': {'up': None, 'down': None}, 'd1': {'up': None, 'down': None}}
 
     feats_1h = {
@@ -179,7 +181,7 @@ def test_range_filter_keeps_strong_signal():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, w=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.5, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None}, '4h': {'up': None, 'down': None}, 'd1': {'up': None, 'down': None}}
 
     feats_1h = {

--- a/tests/test_scoring_layers.py
+++ b/tests/test_scoring_layers.py
@@ -6,6 +6,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_simple_rsg():
@@ -50,6 +51,7 @@ def make_simple_rsg():
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
     rsg.risk_filters = RiskFiltersImpl(rsg)
+    rsg.position_sizer = PositionSizerImpl(rsg)
     return rsg
 
 
@@ -60,7 +62,7 @@ def test_layer_scores_product():
     rsg.factor_scorer.score = lambda f,p:{k:0 for k in rsg.base_weights if k!='ai'}
     rsg.combine_score = lambda ai,fs,w=None: ai
     rsg.dynamic_threshold = lambda *a,**k: (0, 0)
-    rsg.compute_tp_sl = lambda *a,**k:(0,0)
+    rsg.position_sizer.compute_tp_sl = lambda *a,**k:(0,0)
     rsg.models={'1h':{'up':None,'down':None},'4h':{'up':None,'down':None},'d1':{'up':None,'down':None}}
 
     feats={'close':100,'atr_pct_1h':0,'adx_1h':0,'funding_rate_1h':0}

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -11,6 +11,7 @@ from quant_trade.signal.predictor_adapter import PredictorAdapter
 from quant_trade.signal.factor_scorer import FactorScorerImpl
 from quant_trade.signal.fusion_rule import FusionRuleBased
 from quant_trade.signal.risk_filters import RiskFiltersImpl
+from quant_trade.signal.position_sizer import PositionSizerImpl
 
 
 def make_rsg():
@@ -64,6 +65,7 @@ def make_rsg():
     rsg.fuse = rsg.fusion_rule.fuse
     rsg.fuse_multi_cycle = rsg.fusion_rule.fuse
     rsg.risk_filters = RiskFiltersImpl(rsg)
+    rsg.position_sizer = PositionSizerImpl(rsg)
     return rsg
 
 
@@ -81,7 +83,7 @@ def test_vol_roc_guard():
     }
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -9,29 +9,29 @@ from quant_trade.signal.core import compute_dynamic_threshold
 
 def test_compute_tp_sl():
     rsg = make_dummy_rsg()
-    tp, sl = rsg.compute_tp_sl(100, 10, 1)
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 10, 1)
     assert tp == pytest.approx(102)
     assert sl == pytest.approx(95)
 
-    tp, sl = rsg.compute_tp_sl(100, 10, -1)
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 10, -1)
     assert tp == pytest.approx(98)
     assert sl == pytest.approx(105)
 
 
 def test_compute_tp_sl_regime():
     rsg = make_dummy_rsg()
-    tp, sl = rsg.compute_tp_sl(100, 10, 1, regime="range")
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 10, 1, regime="range")
     assert tp == pytest.approx(102)
     assert sl == pytest.approx(95)
 
-    tp, sl = rsg.compute_tp_sl(100, 10, -1, regime="trend")
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 10, -1, regime="trend")
     assert tp == pytest.approx(98)
     assert sl == pytest.approx(105)
 
 
 def test_compute_tp_sl_min_stop_loss():
     rsg = make_dummy_rsg()
-    tp, sl = rsg.compute_tp_sl(100, 10, 1, sl_mult=0.2)
+    tp, sl = rsg.position_sizer.compute_tp_sl(100, 10, 1, sl_mult=0.2)
     assert tp == pytest.approx(102)
     assert sl == pytest.approx(95)
 
@@ -251,7 +251,7 @@ def test_dynamic_threshold_use_raw_features():
     }
     rsg.combine_score = lambda ai, fs, weights=None: 0
     rsg.dynamic_weight_update = lambda: rsg.base_weights
-    rsg.compute_tp_sl = lambda *a, **k: (None, None)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (None, None)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -451,7 +451,7 @@ def test_generate_signal_with_external_metrics():
         r.combine_score = lambda ai, fs, weights=None: 0.5
         r.dynamic_weight_update = lambda: r.base_weights
         r.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-        r.compute_tp_sl = lambda *a, **k: (0, 0)
+        r.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
         r.models = {'1h': {'up': None, 'down': None},
                     '4h': {'up': None, 'down': None},
                     'd1': {'up': None, 'down': None}}
@@ -470,7 +470,7 @@ def test_generate_signal_with_external_metrics():
     rsg.combine_score = base.combine_score
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = base.dynamic_threshold
-    rsg.compute_tp_sl = base.compute_tp_sl
+    rsg.position_sizer.compute_tp_sl = base.position_sizer.compute_tp_sl
     rsg.models = base.models
 
     gm = {'btc_dom_chg': 0.1, 'mcap_growth': 0.1, 'vol_chg': 0.1}
@@ -504,7 +504,7 @@ def test_hot_sector_influence():
     rsg.combine_score = lambda ai, fs, weights=None: 0.5
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -546,7 +546,7 @@ def test_eth_dominance_influence():
     rsg.combine_score = lambda ai, fs, weights=None: 0.5
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -589,7 +589,7 @@ def test_short_momentum_and_order_book():
     rsg.combine_score = lambda ai, fs, weights=None: 0.5
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -634,7 +634,7 @@ def test_ma_cross_logic_amplify():
     rsg.combine_score = lambda ai, fs, weights=None: 0.5
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -735,7 +735,7 @@ def test_order_book_momentum_threshold():
     rsg.combine_score = lambda ai, fs, weights=None: 0.5
     rsg.dynamic_weight_update = lambda: rsg.base_weights
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -783,7 +783,7 @@ def test_sentiment_reweight_and_guard():
 
     rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -817,7 +817,7 @@ def test_volume_and_funding_penalties():
 
     rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -860,7 +860,7 @@ def test_momentum_alignment_disables_confirm():
 
     rsg.factor_scorer.score = fs_func
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -901,7 +901,7 @@ def test_crowding_factor_and_dynamic_threshold():
     rsg.factor_scorer.score = fs_func
     rsg.get_dynamic_oi_threshold = lambda pred_vol=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -940,7 +940,7 @@ def test_step_exit_with_order_book_flip():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -999,7 +999,7 @@ def test_position_size_range_regime():
     }
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {'1h': {'up': None, 'down': None},
                   '4h': {'up': None, 'down': None},
                   'd1': {'up': None, 'down': None}}
@@ -1042,7 +1042,7 @@ def test_generate_signal_with_cls_model():
     }
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.ma_cross_logic = lambda *a, **k: 1.0
     rsg.models = {
         '1h': {'cls': None},
@@ -1081,7 +1081,7 @@ def test_conflict_filter_and_pos_size():
                                           'sentiment': 0, 'funding': 0}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.10, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -1114,7 +1114,7 @@ def test_extreme_indicator_scales_down():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.10, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -1149,7 +1149,7 @@ def test_vote_conflict_scales_score():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: ai
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -1188,7 +1188,7 @@ def test_confirm_15m_adjusts_score():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.0, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},

--- a/tests/test_standardized_logic.py
+++ b/tests/test_standardized_logic.py
@@ -9,7 +9,7 @@ def test_range_filter_respects_vol_breakout_zero():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.5, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},
@@ -46,7 +46,7 @@ def test_break_support_triggers_range_when_standardized():
     rsg.factor_scorer.score = lambda f, p: {k: 0 for k in rsg.base_weights if k != 'ai'}
     rsg.combine_score = lambda ai, fs, weights=None: 0.6
     rsg.dynamic_threshold = lambda *a, **k: (0.1, 0.0)
-    rsg.compute_tp_sl = lambda *a, **k: (0, 0)
+    rsg.position_sizer.compute_tp_sl = lambda *a, **k: (0, 0)
     rsg.models = {
         '1h': {'up': None, 'down': None},
         '4h': {'up': None, 'down': None},


### PR DESCRIPTION
## Summary
- move position sizing and exit logic into new `PositionSizerImpl`
- wire up `RobustSignalGenerator` to use `PositionSizerImpl`
- update tests to call new position sizer interface

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6899db7cc164832a927d7a1dc67a25ed