### PR TITLE
refactor: add signal engine integration

### DIFF
--- a/quant_trade/signal/engine.py
+++ b/quant_trade/signal/engine.py
@@ -121,6 +121,15 @@ class SignalEngine:
         ob_imb = score_details["ob_imb"]
         ts = prepared["ts"]
 
+        phase = getattr(self.rsg, "market_phase", "range")
+        if isinstance(phase, dict):
+            phase = phase.get("phase", "range")
+        mults = getattr(self.rsg, "phase_dir_mult", {})
+        if fused_score > 0:
+            fused_score *= mults.get("long", 1.0)
+        elif fused_score < 0:
+            fused_score *= mults.get("short", 1.0)
+
         pre_res, direction, _ = self.rsg._precheck_and_direction(
             fused_score,
             std_1h,


### PR DESCRIPTION
## Summary
- integrate SignalEngine into core initialization
- delegate signal generation methods to engine.run with context
- apply market phase multipliers in SignalEngine

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6899e8f6f01c832a84de3f4c06e9381d