### PR TITLE
refactor: unify signal package exports

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -39,6 +39,8 @@ from .voting_model import VotingModel, load_cached_model
 from .factor_scorer import FactorScorerImpl
 from .fusion_rule import FusionRuleBased
 from .risk_filters import RiskFiltersImpl
+from .position_sizer import PositionSizerImpl
+from .predictor_adapter import PredictorAdapter
 from .engine import SignalEngine
 
 __all__ = [
@@ -76,5 +78,7 @@ __all__ = [
     "FactorScorerImpl",
     "FusionRuleBased",
     "RiskFiltersImpl",
+    "PositionSizerImpl",
+    "PredictorAdapter",
     "SignalEngine",
 ]

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -2,12 +2,14 @@ import pytest
 
 from collections import deque, OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
-from quant_trade.signal.thresholding_dynamic import ThresholdingDynamic
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    ThresholdingDynamic,
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_dummy_rsg():

--- a/tests/test_factor_scores.py
+++ b/tests/test_factor_scores.py
@@ -2,7 +2,7 @@ import math
 from collections import deque, OrderedDict
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator
-from quant_trade.signal.factor_scorer import FactorScorerImpl
+from quant_trade.signal import FactorScorerImpl
 
 
 def make_rsg():

--- a/tests/test_range_guard.py
+++ b/tests/test_range_guard.py
@@ -1,11 +1,13 @@
 import pytest
 from collections import deque, OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_rsg():

--- a/tests/test_reversal.py
+++ b/tests/test_reversal.py
@@ -3,11 +3,13 @@ import pytest
 from collections import deque, OrderedDict
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, smooth_score
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_rsg():

--- a/tests/test_rsg.py
+++ b/tests/test_rsg.py
@@ -4,11 +4,13 @@ import threading
 import numpy as np
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, DynamicThresholdInput
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_rsg():

--- a/tests/test_scoring_layers.py
+++ b/tests/test_scoring_layers.py
@@ -2,11 +2,13 @@ import pytest
 import numpy as np
 from collections import deque, OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_simple_rsg():

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -7,11 +7,13 @@ from quant_trade.robust_signal_generator import (
     fused_to_risk,
     adjust_score,
 )
-from quant_trade.signal.predictor_adapter import PredictorAdapter
-from quant_trade.signal.factor_scorer import FactorScorerImpl
-from quant_trade.signal.fusion_rule import FusionRuleBased
-from quant_trade.signal.risk_filters import RiskFiltersImpl
-from quant_trade.signal.position_sizer import PositionSizerImpl
+from quant_trade.signal import (
+    PredictorAdapter,
+    FactorScorerImpl,
+    FusionRuleBased,
+    RiskFiltersImpl,
+    PositionSizerImpl,
+)
 
 
 def make_rsg():

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -4,7 +4,7 @@ import pytest
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.data_loader import compute_vix_proxy
 from quant_trade.robust_signal_generator import SignalThresholdParams, DynamicThresholdInput
-from quant_trade.signal.core import compute_dynamic_threshold
+from quant_trade.signal import compute_dynamic_threshold
 
 
 def test_compute_tp_sl():

--- a/tests/test_signal_generator_batch.py
+++ b/tests/test_signal_generator_batch.py
@@ -1,7 +1,7 @@
 import types
 from collections import OrderedDict
 from quant_trade.robust_signal_generator import RobustSignalGenerator
-from quant_trade.signal.factor_scorer import FactorScorerImpl
+from quant_trade.signal import FactorScorerImpl
 
 
 def test_generate_signal_batch_order_and_diagnose():

--- a/tests/test_signal_generator_misc.py
+++ b/tests/test_signal_generator_misc.py
@@ -4,7 +4,7 @@ from collections import deque, OrderedDict
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.market_phase import get_market_phase
-from quant_trade.signal.factor_scorer import FactorScorerImpl
+from quant_trade.signal import FactorScorerImpl
 
 
 def make_rsg():

--- a/tests/test_voting_model.py
+++ b/tests/test_voting_model.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from quant_trade.signal.voting_model import VotingModel
+from quant_trade.signal import VotingModel
 
 
 def test_voting_model_train_and_predict(tmp_path):


### PR DESCRIPTION
## Summary
- export PositionSizerImpl and PredictorAdapter from `quant_trade.signal`
- simplify tests to import classes/functions directly from `quant_trade.signal`

## Testing
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6899f57165f8832aaf6f15939e0e85d2