### PR TITLE
添加信号生成黄金单测

### DIFF
--- a/tests/fixtures/golden_single.json
+++ b/tests/fixtures/golden_single.json
@@ -1,0 +1,100 @@
+{
+  "expected": {
+    "details": {
+      "ai": {
+        "1h": 0.123456,
+        "4h": 0.123456,
+        "d1": 0.123456
+      },
+      "confidence_factor": 1.05,
+      "confirm_15m": 0.0,
+      "conflict_filter_triggered": false,
+      "consensus_14": null,
+      "consensus_4d1": null,
+      "consensus_all": null,
+      "env": {
+        "env_score": 1.0,
+        "logic_score": 0.0123456,
+        "risk_score": 0.75
+      },
+      "exit": {
+        "dynamic_th_final": 0.08669007127452362,
+        "regime": "range",
+        "reversal_flag": 0
+      },
+      "extreme_reversal": false,
+      "factors": {
+        "1h": {
+          "funding": 0.0,
+          "momentum": 0.0,
+          "sentiment": 0.0,
+          "trend": 0.0,
+          "volatility": 0.0,
+          "volume": 0.0
+        },
+        "4h": {
+          "funding": 0.0,
+          "momentum": 0.0,
+          "sentiment": 0.0,
+          "trend": 0.0,
+          "volatility": 0.0,
+          "volume": 0.0
+        },
+        "d1": {
+          "funding": 0.0,
+          "momentum": 0.0,
+          "sentiment": 0.0,
+          "trend": 0.0,
+          "volatility": 0.0,
+          "volume": 0.0
+        }
+      },
+      "fast_cross": 0,
+      "grad_dir": 0.0,
+      "ma_cross": 0,
+      "ob_imbalance": 0.0,
+      "pos_size": 0.09110594001952546,
+      "position_tier": 0.0,
+      "protect": {
+        "crowding_factor": 1.0,
+        "funding_conflicts": 0,
+        "oi_overheat": null,
+        "oi_threshold": null
+      },
+      "reb_boost_applied": false,
+      "scores": {
+        "1h": 0.010288,
+        "4h": 0.010288,
+        "d1": 0.010288
+      },
+      "short_momentum": 0.0,
+      "vol_ratio": null,
+      "vote": {
+        "confidence": 0.5,
+        "ob_th": 0.1,
+        "value": 2
+      }
+    },
+    "position_size": 0.0911,
+    "score": 0.010956281570688927,
+    "signal": 0
+  },
+  "features": {
+    "15m": {},
+    "1h": {},
+    "4h": {},
+    "d1": {}
+  },
+  "global_metrics": {},
+  "open_interest": {
+    "oi_chg": 0
+  },
+  "order_book_imbalance": 0,
+  "raw": {
+    "15m": {},
+    "1h": {},
+    "4h": {},
+    "d1": {}
+  },
+  "symbol": "BTCUSDT"
+}

--- a/tests/signal/test_golden_single.py
+++ b/tests/signal/test_golden_single.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quant_trade.robust_signal_generator import RobustSignalGenerator, RobustSignalGeneratorConfig
+import quant_trade.signal.core as core
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+@pytest.fixture(params=sorted(FIXTURE_DIR.glob("*.json")))
+def case_data(request):
+    return load_json(request.param)
+
+def test_golden_single(case_data, monkeypatch):
+    class DummyAI:
+        def __init__(self, model_paths):
+            self.models = {p: {"up": {"features": []}, "down": {"features": []}} for p in ("1h", "4h", "d1")}
+            self.calibrators = {p: {"up": None, "down": None} for p in ("1h", "4h", "d1")}
+        def get_ai_score(self, *a, **k):
+            return 0.123456
+
+    monkeypatch.setattr(core, "AIModelPredictor", DummyAI)
+
+    cfg = RobustSignalGeneratorConfig(
+        model_paths={p: {"up": "dummy", "down": "dummy"} for p in ("1h", "4h", "d1")},
+        feature_cols_1h=[],
+        feature_cols_4h=[],
+        feature_cols_d1=[],
+    )
+    rsg = RobustSignalGenerator(cfg)
+
+    features = case_data["features"]
+    raw = case_data["raw"]
+    result = rsg.generate_signal(
+        features["1h"],
+        features["4h"],
+        features["d1"],
+        features.get("15m"),
+        raw_features_1h=raw["1h"],
+        raw_features_4h=raw["4h"],
+        raw_features_d1=raw["d1"],
+        raw_features_15m=raw.get("15m"),
+        global_metrics=case_data.get("global_metrics"),
+        open_interest=case_data.get("open_interest"),
+        order_book_imbalance=case_data.get("order_book_imbalance"),
+        symbol=case_data.get("symbol"),
+    )
+
+    expected = case_data["expected"]
+
+    assert isinstance(result, dict)
+    for key in ("signal", "score", "position_size", "details"):
+        assert key in result
+
+    assert abs(result["signal"] - expected["signal"]) <= 1e-6
+    assert abs(result["score"] - expected["score"]) <= 1e-6
+    assert abs(result["position_size"] - expected["position_size"]) <= 1e-6
+
+    details = result["details"]
+    for field in ("vote", "protect", "env", "exit", "factors"):
+        assert field in details
+
+    rsg.stop_weight_update_thread()


### PR DESCRIPTION
## Summary
- 新增 golden_single JSON 夹具并构建最小示例数据
- 引入固定返回常数的 DummyAI 以替换 AIModelPredictor
- 覆盖所有夹具文件并校验 signal/score/position_size 及 details 关键字段

## Testing
- `pytest -q tests/signal/test_golden_single.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a0238b170832ab0682af070f3e22b