### PR TITLE
添加用于运行测试的 Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test test-quick
+test:
+	pytest
+test-quick:
+	pytest tests/signal/test_golden_single.py tests/signal/test_golden_batch.py -q


### PR DESCRIPTION
## Summary
- 新增 Makefile，提供 test 与 test-quick 两个目标，便于运行全部或部分测试

## Testing
- `pytest tests`
- `make test`
- `make test-quick`


------
https://chatgpt.com/codex/tasks/task_e_689aa6eeeec8832aa1d8f6bd54361194