### PR TITLE
添加 Ruff 与 Mypy 配置

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
-.PHONY: test test-quick
-test:
-	pytest
+.RECIPEPREFIX := >
+
+.PHONY: lint test test-quick
+
+lint:
+>ruff check --fix .
+>mypy .
+
+test: lint
+>pytest
+
 test-quick:
-	pytest tests/signal/test_golden_single.py tests/signal/test_golden_batch.py -q
+>pytest tests/signal/test_golden_single.py tests/signal/test_golden_batch.py -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+incremental = true
+cache_dir = ".mypy_cache"


### PR DESCRIPTION
## Summary
- 配置 Ruff 选择规则并忽略测试中的长字符串
- 新增 Ruff 自动修复与 Mypy 检查的 Makefile 目标

## Testing
- `ruff check --fix --diff .`
- `mypy .` *(fails: missing library stubs)*
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_689ab4d9f108832a89ab9ffbca1db2f1