### PR TITLE
chore: add type hints to feature processor

### DIFF
--- a/quant_trade/feature_processor.py
+++ b/quant_trade/feature_processor.py
@@ -1,12 +1,17 @@
 class FeatureProcessor:
     """特征处理逻辑"""
 
-    def __init__(self, feature_cols_1h, feature_cols_4h, feature_cols_d1):
+    def __init__(
+        self,
+        feature_cols_1h: list[str],
+        feature_cols_4h: list[str],
+        feature_cols_d1: list[str],
+    ) -> None:
         self.feature_cols = {
             "1h": feature_cols_1h,
             "4h": feature_cols_4h,
             "d1": feature_cols_d1,
         }
 
-    def get_columns(self, period: str):
+    def get_columns(self, period: str) -> list[str]:
         return self.feature_cols.get(period, [])


### PR DESCRIPTION
## Summary
- annotate FeatureProcessor with concrete list types
- type annotate get_columns return

## Testing
- `ruff check --fix quant_trade/feature_processor.py`
- `mypy --ignore-missing-imports --follow-imports=skip quant_trade/feature_processor.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689ab7ef1954832a9ef12f5ddd60d2db