### PR TITLE
Add environment-configurable logger helper

### DIFF
--- a/quant_trade/logging.py
+++ b/quant_trade/logging.py
@@ -1,0 +1,19 @@
+import logging
+import os
+
+_LOG_LEVEL_NAME = os.getenv('QT_LOG_LEVEL', 'INFO').upper()
+try:
+    _LOG_LEVEL = getattr(logging, _LOG_LEVEL_NAME)
+except AttributeError:
+    _LOG_LEVEL = logging.INFO
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with level defined by ``QT_LOG_LEVEL`` env variable.
+
+    The logger uses existing handlers and formatting without modifications.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(_LOG_LEVEL)
+    return logger
+


### PR DESCRIPTION
## Summary
- add `quant_trade.logging` module with `get_logger` using `QT_LOG_LEVEL`

## Testing
- `pytest -q tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689ad7368b68832a8a4a441daaae36a9