### PR TITLE
feat: add optional SignalConfig validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ print(community_metrics()[:5])
 
 在开始之前，请执行 `pip install -r requirements.txt` 安装依赖。
 
+若需在加载配置时启用自动校验，可额外安装可选依赖 `pydantic`：
+
+```bash
+pip install pydantic
+```
+
+未安装时程序会跳过校验，继续使用原始配置。
+
 完成安装后，可运行 `pytest -q tests` 执行自带的单元测试。
 
 ```bash

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,50 @@
+
+import yaml
+import logging
+from pathlib import Path
+
+import pytest
+
+from quant_trade.config_schema import SignalConfig
+from quant_trade.robust_signal_generator import (
+    RobustSignalGenerator,
+    RobustSignalGeneratorConfig,
+)
+
+
+def _write_cfg(tmp_path: Path, cfg: dict) -> Path:
+    path = tmp_path / "config.yaml"
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f, allow_unicode=True)
+    return path
+
+
+def _make_rsg(tmp_path: Path, cfg: dict):
+    cfg_path = _write_cfg(tmp_path, cfg)
+    init_cfg = {
+        "models": {},
+        "feature_cols": {
+            "1h": ["rsi_1h"],
+            "4h": ["rsi_4h"],
+            "d1": ["rsi_d1"],
+        },
+        "enable_ai": False,
+    }
+    config_obj = RobustSignalGeneratorConfig.from_cfg(init_cfg, cfg_path)
+    return RobustSignalGenerator(config_obj)
+
+
+def test_cfg_validation_success(tmp_path):
+    cfg = SignalConfig().model_dump()
+    rsg = _make_rsg(tmp_path, cfg)
+    assert rsg.cfg == cfg
+
+
+def test_cfg_validation_warning(tmp_path, caplog):
+    cfg = SignalConfig().model_dump()
+    cfg["penalty_factor"] = "bad"
+    with caplog.at_level(logging.WARNING):
+        rsg = _make_rsg(tmp_path, cfg)
+    assert "Config validation failed" in caplog.text
+    assert rsg.cfg["penalty_factor"] == "bad"
+


### PR DESCRIPTION
## Summary
- validate configuration with optional `SignalConfig` when available
- handle invalid config gracefully and preserve original values
- document optional Pydantic dependency and add regression tests

## Testing
- `pytest -q tests/test_config_validation.py`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_689ae7442800832aa219bc5e945100ed