### PR TITLE
feat: add thread-safe LRU cache

### DIFF
--- a/quant_trade/utils/__init__.py
+++ b/quant_trade/utils/__init__.py
@@ -1,4 +1,5 @@
 from .ratelimiter import RateLimiter
+from .lru import LRU
 from .helper import (
     calc_order_book_features,
     collect_feature_cols,
@@ -34,4 +35,5 @@ __all__ = [
     "load_config",
     "connect_mysql",
     "community_metrics",
+    "LRU",
 ]

--- a/quant_trade/utils/lru.py
+++ b/quant_trade/utils/lru.py
@@ -1,0 +1,36 @@
+from collections import OrderedDict
+from threading import Lock
+
+
+class LRU:
+    """线程安全的 LRU 缓存。"""
+
+    def __init__(self, maxsize: int = 128) -> None:
+        self.maxsize = maxsize
+        self._cache: OrderedDict = OrderedDict()
+        self._lock = Lock()
+
+    def get(self, key):
+        """获取缓存值，若不存在返回 ``None``。"""
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+                return self._cache[key]
+            return None
+
+    def set(self, key, value) -> None:
+        """设置缓存值并在超出容量时淘汰最旧的条目。"""
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+            self._cache[key] = value
+            if len(self._cache) > self.maxsize:
+                self._cache.popitem(last=False)
+
+    def __len__(self) -> int:  # 可选，用于调试和测试
+        with self._lock:
+            return len(self._cache)
+
+    def __contains__(self, key) -> bool:  # 可选
+        with self._lock:
+            return key in self._cache

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,0 +1,39 @@
+import threading
+
+from quant_trade.utils.lru import LRU
+
+
+def test_set_get_evict():
+    cache = LRU(maxsize=2)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    assert cache.get("a") == 1
+    cache.set("c", 3)  # should evict key "b"
+    assert "b" not in cache
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+
+
+def test_len_and_contains():
+    cache = LRU(maxsize=1)
+    assert len(cache) == 0
+    cache.set("x", 10)
+    assert len(cache) == 1
+    assert "x" in cache
+    assert cache.get("x") == 10
+
+
+def test_thread_safety():
+    cache = LRU(maxsize=10)
+
+    def writer(key):
+        for i in range(100):
+            cache.set(key, i)
+
+    threads = [threading.Thread(target=writer, args=(f"k{i}",)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(cache) <= 10


### PR DESCRIPTION
## Summary
- add thread-safe LRU cache utility based on OrderedDict
- expose LRU via utils package
- cover cache logic with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af3213100832a99995bfd5ced8777