### PR TITLE
重构缓存为线程安全的 LRU

### DIFF
--- a/quant_trade/signal/factor_scorer.py
+++ b/quant_trade/signal/factor_scorer.py
@@ -21,7 +21,7 @@ class FactorScorerImpl:
     # 原 get_factor_scores -> score
     def score(self, features: Mapping, period: str) -> dict:
         key = self.core._make_cache_key(features, period)
-        cached = self.core._cache_get(self.core._factor_cache, key)
+        cached = self.core._factor_cache.get(key)
         if cached is not None:
             return cached
 
@@ -82,7 +82,7 @@ class FactorScorerImpl:
             elif pos < 0.1 and v < 0:
                 scores[k] = v * 0.8
 
-        self.core._cache_set(self.core._factor_cache, key, scores)
+        self.core._factor_cache.set(key, scores)
         return scores
 
     # 原 calc_factor_scores

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal import (
     ThresholdingDynamic,
@@ -14,7 +16,7 @@ from quant_trade.signal import (
 
 def make_dummy_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)

--- a/tests/test_factor_scores.py
+++ b/tests/test_factor_scores.py
@@ -1,5 +1,7 @@
 import math
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal import FactorScorerImpl
@@ -7,7 +9,7 @@ from quant_trade.signal import FactorScorerImpl
 
 def make_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.base_weights = {
         'ai': 0.2,

--- a/tests/test_range_guard.py
+++ b/tests/test_range_guard.py
@@ -1,5 +1,7 @@
 import pytest
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal import (
     PredictorAdapter,
@@ -12,7 +14,7 @@ from quant_trade.signal import (
 
 def make_rsg():
     r = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    r._factor_cache = OrderedDict()
+    r._factor_cache = LRU(300)
     r.factor_scorer = FactorScorerImpl(r)
     r.history_scores = deque(maxlen=500)
     r.oi_change_history = deque(maxlen=500)

--- a/tests/test_reversal.py
+++ b/tests/test_reversal.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, smooth_score
 from quant_trade.signal import (
@@ -14,7 +16,7 @@ from quant_trade.signal import (
 
 def make_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)

--- a/tests/test_rsg.py
+++ b/tests/test_rsg.py
@@ -1,7 +1,9 @@
 import pytest
-from collections import deque, OrderedDict
+from collections import deque
 import threading
 import numpy as np
+
+from quant_trade.utils.lru import LRU
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, DynamicThresholdInput
 from quant_trade.signal import (
@@ -15,7 +17,7 @@ from quant_trade.signal import (
 
 def make_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)

--- a/tests/test_scoring_layers.py
+++ b/tests/test_scoring_layers.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal import (
     PredictorAdapter,
@@ -13,7 +15,7 @@ from quant_trade.signal import (
 
 def make_simple_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=10)
     rsg.oi_change_history = deque(maxlen=10)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,5 +1,7 @@
 import pytest
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 
 from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
@@ -18,7 +20,7 @@ from quant_trade.signal import (
 
 def make_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)

--- a/tests/test_signal_generator_batch.py
+++ b/tests/test_signal_generator_batch.py
@@ -1,12 +1,12 @@
 import types
-from collections import OrderedDict
+from quant_trade.utils.lru import LRU
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.signal import FactorScorerImpl
 
 
 def test_generate_signal_batch_order_and_diagnose():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    rsg._factor_cache = OrderedDict()
+    rsg._factor_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)
     def stub_generate_signal(f1, f4, fd, *a, **k):
         rsg._diagnostic = {"id": f1["id"]}

--- a/tests/test_signal_generator_misc.py
+++ b/tests/test_signal_generator_misc.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
-from collections import deque, OrderedDict
+from collections import deque
+
+from quant_trade.utils.lru import LRU
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator
 from quant_trade.market_phase import get_market_phase
@@ -9,7 +11,7 @@ from quant_trade.signal import FactorScorerImpl
 
 def make_rsg():
     r = RobustSignalGenerator.__new__(RobustSignalGenerator)
-    r._factor_cache = OrderedDict()
+    r._factor_cache = LRU(300)
     r.factor_scorer = FactorScorerImpl(r)
     r._prev_raw = {p: None for p in ("1h", "4h", "d1")}
     r.sentiment_alpha = 0.5


### PR DESCRIPTION
## Summary
- 引入 `LRU` 并将 `RobustSignalGenerator` 的四个缓存替换为 LRU 实现
- 删除 `_cache_get/_cache_set`，直接使用 `cache.get` / `cache.set`
- 更新相关测试用例以适配新的缓存接口

## Testing
- `pytest tests | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689af62831d8832a9c4fd2d3ff944158