### PR TITLE
默认启用 filter_penalty_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,11 @@ crowding_protection:
 risk_filters_enabled: false
 dynamic_threshold_enabled: true
 direction_filters_enabled: true
-filter_penalty_mode: false    # true 时仅惩罚得分，不直接弃用
+filter_penalty_mode: true     # true 时仅惩罚得分，不直接弃用
 penalty_factor: 0.5           # 惩罚系数，越低扣减越多
 ```
-启用 `filter_penalty_mode` 后，资金费率冲突或风险值超限时不会直接丢弃信号，而是按
-`penalty_factor` 缩减得分和仓位。
-关闭后 `apply_risk_filters` 会直接返回得分，`compute_position_size` 也不会再根据风险值提高仓位下限。默认情况下仍会执行 `compute_dynamic_threshold` 更新 `base_th`；若希望保持固定阈值，可同时将 `dynamic_threshold_enabled` 设为 `false`。
+默认启用 `filter_penalty_mode`，资金费率冲突或风险值超限时不会直接丢弃信号，而是按 `penalty_factor` 缩减得分和仓位。
+将其设为 `false` 后，`apply_risk_filters` 会直接返回得分，`compute_position_size` 也不会再根据风险值提高仓位下限。默认情况下仍会执行 `compute_dynamic_threshold` 更新 `base_th`；若希望保持固定阈值，可同时将 `dynamic_threshold_enabled` 设为 `false`。
 `direction_filters_enabled` 则控制是否执行方向与仓位过滤，设为 `false` 时 `_determine_direction` 和 `_apply_position_filters` 将直接返回原始结果。
 
 ### 启用或禁用 AI 模型

--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -446,7 +446,7 @@ class RobustSignalGenerator:
         self.risk_filters_enabled = cfg.get("risk_filters_enabled", True)
         self.dynamic_threshold_enabled = cfg.get("dynamic_threshold_enabled", True)
         self.direction_filters_enabled = cfg.get("direction_filters_enabled", True)
-        self.filter_penalty_mode = cfg.get("filter_penalty_mode", False)
+        self.filter_penalty_mode = cfg.get("filter_penalty_mode", True)
         self.rsi_k = get_cfg_value(cfg, "rsi_k", DEFAULT_RSI_K)
         self.penalty_factor = get_cfg_value(cfg, "penalty_factor", 0.5)
         fe_cfg = cfg.get("feature_engineering", {})


### PR DESCRIPTION
## Summary
- 默认将 `filter_penalty_mode` 设为开启，避免风险过滤时直接丢弃信号
- 同步更新 README 示例以反映新的默认配置

## Testing
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_689b3c508b54832a83b57aae2601fe50