### PR TITLE
保留因子方向冲突标记

### DIFF
--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -1750,8 +1750,7 @@ class RobustSignalGenerator:
                 ai_scores[p] = 0.0
 
         signs = {int(np.sign(v)) for v in ai_scores.values() if v != 0}
-        if len(signs) > 1:
-            return None
+        conflict = len(signs) > 1
 
         raw_dict = {
             "1h": feats_1h.raw,
@@ -1777,6 +1776,7 @@ class RobustSignalGenerator:
         )
         cached = self._factor_score_cache.get(key)
         if cached is not None:
+            cached["conflict"] = conflict
             return cached
         std_1h = feats_1h.std
         std_4h = feats_4h.std
@@ -1955,6 +1955,7 @@ class RobustSignalGenerator:
             "oi_overheat": oi_overheat,
             "th_oi": th_oi,
             "oi_chg": oi_chg,
+            "conflict": conflict,
         }
         self._factor_score_cache.set(key, result)
         return result
@@ -2567,6 +2568,7 @@ class RobustSignalGenerator:
             "consensus_14": risk_info.get("consensus_14"),
             "consensus_4d1": risk_info.get("consensus_4d1"),
             "extreme_reversal": extreme_reversal,
+            "conflict": scores.get("conflict"),
             "conflict_filter_triggered": conflict_filter_triggered,
             "confirm_15m": confirm_15m,
             "reb_boost_applied": reb_boost_applied,

--- a/quant_trade/signal/engine.py
+++ b/quant_trade/signal/engine.py
@@ -123,6 +123,7 @@ class SignalEngine:
         env_score = scores["env_score"]
         fs = scores["fs"]
         score_details = scores["scores"]
+        score_details["conflict"] = scores.get("conflict")
         ai_scores = score_details["ai_scores"]
         vol_preds = score_details["vol_preds"]
         rise_preds = score_details["rise_preds"]

--- a/tests/test_new_funcs.py
+++ b/tests/test_new_funcs.py
@@ -120,7 +120,7 @@ def test_fuse_multi_cycle():
     assert c3
 
 
-def test_ai_dir_inconsistent_returns_none():
+def test_ai_dir_inconsistent_flagged():
     rsg = make_dummy_rsg()
     rsg.ai_dir_eps = 0.1
     rsg.factor_scorer.calc_factor_scores = lambda ai, fs, w: ai
@@ -141,7 +141,7 @@ def test_ai_dir_inconsistent_returns_none():
         None,
         None,
     )
-    assert res is None
+    assert res is not None and res["conflict"]
 
 
 def test_ai_dir_eps_threshold_check():
@@ -165,7 +165,7 @@ def test_ai_dir_eps_threshold_check():
         None,
         None,
     )
-    assert res is None
+    assert res is not None and res["conflict"]
 
 
 def test_compute_exit_multiplier():

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -1030,7 +1030,7 @@ def test_position_size_range_regime():
         raw_features_4h=f4h,
         raw_features_d1=fd1,
     )
-    assert res is None
+    assert res is not None and res["details"]["conflict"]
 
 
 def test_generate_signal_with_cls_model():


### PR DESCRIPTION
## Summary
- compute_factor_scores 不再在方向冲突时返回 None，而是记录 conflict 标记
- 引擎及仓位计算流程传播 conflict，最终信号详情包含该标记
- 更新测试以验证冲突标记逻辑

## Testing
- `pytest tests -p no:warnings`


------
https://chatgpt.com/codex/tasks/task_e_689bc5f85f5c832abc3600db965d85a2