### PR TITLE
refactor: add dynamic thresholds module

### DIFF
--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -15,10 +15,11 @@ from .signal.core import (
     DEFAULTS,
     SAFE_FALLBACKS,
 )
-from .signal.thresholding_dynamic import (
+from .signal.dynamic_thresholds import (
     ThresholdingDynamic,
     DynamicThresholdInput,
     compute_dynamic_threshold,
+    calc_dynamic_threshold,
 )
 from .signal.utils import (
     softmax,
@@ -45,6 +46,7 @@ __all__ = [
     "RobustSignalGenerator",
     "ThresholdingDynamic",
     "compute_dynamic_threshold",
+    "calc_dynamic_threshold",
     "DEFAULT_AI_DIR_EPS",
     "DEFAULT_POS_K_RANGE",
     "DEFAULT_POS_K_TREND",

--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -15,10 +15,11 @@ from .core import (
     DEFAULTS,
     SAFE_FALLBACKS,
 )
-from .thresholding_dynamic import (
+from .dynamic_thresholds import (
     ThresholdingDynamic,
     DynamicThresholdInput,
     compute_dynamic_threshold,
+    calc_dynamic_threshold,
 )
 from .utils import (
     softmax,
@@ -53,6 +54,7 @@ __all__ = [
     "RobustSignalGenerator",
     "ThresholdingDynamic",
     "compute_dynamic_threshold",
+    "calc_dynamic_threshold",
     "DEFAULT_AI_DIR_EPS",
     "DEFAULT_POS_K_RANGE",
     "DEFAULT_POS_K_TREND",

--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -180,10 +180,11 @@ from .multi_period_fusion import (
 )
 from .fusion_rule import combine_score as _combine_score, combine_score_vectorized as _combine_score_vectorized
 from .risk_filters import RiskFiltersImpl
-from .thresholding_dynamic import (
+from .dynamic_thresholds import (
     ThresholdingDynamic,
     DynamicThresholdInput,
     compute_dynamic_threshold,
+    calc_dynamic_threshold,
 )
 from .position_sizer import PositionSizerImpl
 
@@ -1279,28 +1280,19 @@ class RobustSignalGenerator:
         low_base: float | None = None,
         history_scores=None,
     ):
-        """Delegate to :class:`ThresholdingDynamic` base method."""
+        """入口函数 :func:`calc_dynamic_threshold` 的简单封装."""
 
-        return self.thresholding.base(
-            data.atr,
-            data.adx,
-            funding=data.funding,
-            atr_4h=data.atr_4h,
-            adx_4h=data.adx_4h,
-            atr_d1=data.atr_d1,
-            adx_d1=data.adx_d1,
-            bb_width_chg=data.bb_width_chg,
-            channel_pos=data.channel_pos,
-            pred_vol=data.pred_vol,
-            pred_vol_4h=data.pred_vol_4h,
-            pred_vol_d1=data.pred_vol_d1,
-            vix_proxy=data.vix_proxy,
-            base=base,
-            regime=data.regime,
-            low_base=low_base,
-            reversal=data.reversal,
-            history_scores=history_scores,
-        )
+        data.base = base
+        data.low_base = low_base
+        data.history_scores = history_scores
+        data.signal_params = self.signal_params
+        data.dynamic_params = self.dynamic_th_params
+        data.smooth_window = getattr(self, "smooth_window", 20)
+        data.smooth_alpha = getattr(self, "smooth_alpha", 0.2)
+        data.smooth_limit = getattr(self, "smooth_limit", 1.0)
+        data.th_window = getattr(self, "th_window", 60)
+        data.th_decay = getattr(self, "th_decay", 2.0)
+        return calc_dynamic_threshold(data)
 
     # Backward compatible property for easier monkeypatching
     @property

--- a/quant_trade/signal/dynamic_thresholds.py
+++ b/quant_trade/signal/dynamic_thresholds.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+"""Dynamic thresholding utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from dataclasses import dataclass
+from typing import Iterable, TYPE_CHECKING
+
+from .utils import smooth_series, _calc_history_base
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from .core import SignalThresholdParams, DynamicThresholdParams
+
+
+def compute_dynamic_threshold(history_scores: Iterable[float], window: int, quantile: float):
+    """Compute absolute score threshold from history."""
+    if not history_scores:
+        return None
+    arr = np.abs(np.asarray(list(history_scores)[-window:], dtype=float))
+    if arr.size == 0:
+        return None
+    return float(np.quantile(arr, quantile))
+
+
+@dataclass
+class DynamicThresholdInput:
+    """Container for metrics used in dynamic threshold calculation."""
+
+    atr: float
+    adx: float
+    bb_width_chg: float | None = None
+    channel_pos: float | None = None
+    funding: float = 0.0
+    atr_4h: float | None = None
+    adx_4h: float | None = None
+    atr_d1: float | None = None
+    adx_d1: float | None = None
+    pred_vol: float | None = None
+    pred_vol_4h: float | None = None
+    pred_vol_d1: float | None = None
+    vix_proxy: float | None = None
+    regime: str | None = None
+    reversal: bool = False
+    base: float | None = None
+    low_base: float | None = None
+    history_scores: Iterable[float] | None = None
+    signal_params: "SignalThresholdParams | None" = None
+    dynamic_params: "DynamicThresholdParams | None" = None
+    smooth_window: int = 20
+    smooth_alpha: float = 0.2
+    smooth_limit: float | None = 1.0
+    th_window: int = 60
+    th_decay: float = 2.0
+
+
+def _classify_regime(adx: float | None, bb_width_chg: float | None) -> str:
+    """Simple market regime classification used when regime is not provided."""
+    if adx is None or bb_width_chg is None:
+        return "unknown"
+    try:
+        adx = float(adx)
+        bb_chg = float(bb_width_chg)
+    except (TypeError, ValueError):
+        return "unknown"
+    if adx >= 25 and bb_chg > 0:
+        return "trend"
+    if adx <= 20 and bb_chg < 0:
+        return "range"
+    return "unknown"
+
+
+def calc_dynamic_threshold(params: DynamicThresholdInput) -> tuple[float, float]:
+    """Calculate dynamic threshold and reversal boost.
+
+    Parameters are provided via :class:`DynamicThresholdInput`.
+    """
+    from .core import SignalThresholdParams, DynamicThresholdParams  # local import
+
+    sig_p = params.signal_params or SignalThresholdParams()
+    dyn_p = params.dynamic_params or DynamicThresholdParams()
+
+    base = sig_p.base_th if params.base is None else params.base
+    low_base = sig_p.low_base if params.low_base is None else params.low_base
+
+    if params.history_scores is not None:
+        scores = smooth_series(
+            params.history_scores,
+            window=params.smooth_window,
+            alpha=params.smooth_alpha,
+        )
+        if params.smooth_limit is not None:
+            scores = np.clip(scores, -params.smooth_limit, params.smooth_limit)
+        hist_base = _calc_history_base(
+            scores,
+            base,
+            sig_p.quantile,
+            params.th_window,
+            params.th_decay,
+            0.12,
+        )
+    else:
+        hist_base = base
+
+    th = hist_base
+    atr_eff = abs(params.atr)
+    if params.atr_4h is not None:
+        atr_eff += 0.5 * abs(params.atr_4h)
+    if params.atr_d1 is not None:
+        atr_eff += 0.25 * abs(params.atr_d1)
+    th += min(dyn_p.atr_cap, atr_eff * dyn_p.atr_mult)
+
+    fund_eff = abs(params.funding)
+    if params.pred_vol is not None:
+        fund_eff += 0.5 * abs(params.pred_vol)
+    if params.pred_vol_4h is not None:
+        fund_eff += 0.25 * abs(params.pred_vol_4h)
+    if params.pred_vol_d1 is not None:
+        fund_eff += 0.15 * abs(params.pred_vol_d1)
+    if params.vix_proxy is not None:
+        fund_eff += 0.25 * abs(params.vix_proxy)
+    th += min(dyn_p.funding_cap, fund_eff * dyn_p.funding_mult)
+
+    adx_eff = abs(params.adx)
+    if params.adx_4h is not None:
+        adx_eff += 0.5 * abs(params.adx_4h)
+    if params.adx_d1 is not None:
+        adx_eff += 0.25 * abs(params.adx_d1)
+    th += min(dyn_p.adx_cap, adx_eff / dyn_p.adx_div)
+
+    if atr_eff == 0 and adx_eff == 0 and fund_eff == 0:
+        th = min(th, hist_base)
+
+    regime = params.regime or _classify_regime(params.adx, params.bb_width_chg)
+    if params.reversal:
+        th *= sig_p.rev_th_mult
+
+    rev_boost = sig_p.rev_boost
+    if regime == "trend":
+        th *= 1.05
+        rev_boost *= 0.8
+    elif regime == "range":
+        th *= 0.95
+        rev_boost *= 1.2
+
+    return max(th, low_base), rev_boost
+
+
+class ThresholdingDynamic:
+    """Dynamic thresholding helper bound to a generator instance."""
+
+    def __init__(self, owner):
+        self.owner = owner
+
+    @staticmethod
+    def adaptive_rsi_threshold(
+        rsi_series, vol_series, k: float | None = None, window: int = 14
+    ):
+        """Weighted standard deviation based RSI thresholds."""
+        if rsi_series is None or vol_series is None:
+            return 30.0, 70.0
+        rsi_series = pd.Series(rsi_series).astype(float)
+        vol_series = pd.Series(vol_series).astype(float)
+        df = pd.DataFrame({"rsi": rsi_series, "vol": vol_series}).dropna()
+        if df.empty or len(df) < window:
+            return 30.0, 70.0
+        roll = df.tail(window)
+        weights = roll["vol"].to_numpy()
+        rsi_vals = roll["rsi"].to_numpy()
+        if not np.isfinite(weights).all() or np.allclose(weights, 0):
+            mean = rsi_vals.mean()
+            std = rsi_vals.std(ddof=0)
+        else:
+            mean = np.average(rsi_vals, weights=weights)
+            var = np.average((rsi_vals - mean) ** 2, weights=weights)
+            std = float(np.sqrt(var))
+        if k is None:
+            from .core import DEFAULT_RSI_K  # local import to avoid cycle
+
+            k = DEFAULT_RSI_K
+        lower = float(mean - k * std)
+        upper = float(mean + k * std)
+        return lower, upper
+
+    def base(
+        self,
+        atr,
+        adx,
+        funding=0,
+        *,
+        atr_4h=None,
+        adx_4h=None,
+        atr_d1=None,
+        adx_d1=None,
+        bb_width_chg=None,
+        channel_pos=None,
+        pred_vol=None,
+        pred_vol_4h=None,
+        pred_vol_d1=None,
+        vix_proxy=None,
+        base=None,
+        regime=None,
+        low_base=None,
+        reversal=False,
+        history_scores=None,
+    ):
+        """Compute dynamic threshold and reversal boost."""
+        data = DynamicThresholdInput(
+            atr=atr,
+            adx=adx,
+            bb_width_chg=bb_width_chg,
+            channel_pos=channel_pos,
+            funding=funding,
+            atr_4h=atr_4h,
+            adx_4h=adx_4h,
+            atr_d1=atr_d1,
+            adx_d1=adx_d1,
+            pred_vol=pred_vol,
+            pred_vol_4h=pred_vol_4h,
+            pred_vol_d1=pred_vol_d1,
+            vix_proxy=vix_proxy,
+            regime=regime,
+            reversal=reversal,
+            base=base,
+            low_base=low_base,
+            history_scores=history_scores,
+            signal_params=self.owner.signal_params,
+            dynamic_params=self.owner.dynamic_th_params,
+            smooth_window=getattr(self.owner, "smooth_window", 20),
+            smooth_alpha=getattr(self.owner, "smooth_alpha", 0.2),
+            smooth_limit=getattr(self.owner, "smooth_limit", 1.0),
+            th_window=getattr(self.owner, "th_window", 60),
+            th_decay=getattr(self.owner, "th_decay", 2.0),
+        )
+        return calc_dynamic_threshold(data)
+
+
+# Re-export for backward compatibility
+adaptive_rsi_threshold = ThresholdingDynamic.adaptive_rsi_threshold
+
+__all__ = [
+    "compute_dynamic_threshold",
+    "DynamicThresholdInput",
+    "calc_dynamic_threshold",
+    "ThresholdingDynamic",
+    "adaptive_rsi_threshold",
+]

--- a/quant_trade/signal/thresholding_dynamic.py
+++ b/quant_trade/signal/thresholding_dynamic.py
@@ -1,172 +1,18 @@
 # -*- coding: utf-8 -*-
-"""Dynamic thresholding utilities."""
+"""Compatibility wrappers for dynamic thresholding utilities."""
 
-from __future__ import annotations
+from .dynamic_thresholds import (
+    compute_dynamic_threshold,
+    DynamicThresholdInput,
+    ThresholdingDynamic,
+    calc_dynamic_threshold,
+    adaptive_rsi_threshold,
+)
 
-import numpy as np
-import pandas as pd
-from dataclasses import dataclass
-from typing import Iterable
-
-from .utils import smooth_series, _calc_history_base
-
-
-def compute_dynamic_threshold(history_scores: Iterable[float], window: int, quantile: float):
-    """Compute absolute score threshold from history."""
-    if not history_scores:
-        return None
-    arr = np.abs(np.asarray(list(history_scores)[-window:], dtype=float))
-    if arr.size == 0:
-        return None
-    return float(np.quantile(arr, quantile))
-
-
-@dataclass
-class DynamicThresholdInput:
-    """Container for metrics used in dynamic threshold calculation."""
-
-    atr: float
-    adx: float
-    bb_width_chg: float | None = None
-    channel_pos: float | None = None
-    funding: float = 0.0
-    atr_4h: float | None = None
-    adx_4h: float | None = None
-    atr_d1: float | None = None
-    adx_d1: float | None = None
-    pred_vol: float | None = None
-    pred_vol_4h: float | None = None
-    pred_vol_d1: float | None = None
-    vix_proxy: float | None = None
-    regime: str | None = None
-    reversal: bool = False
-
-
-class ThresholdingDynamic:
-    """Dynamic thresholding helper bound to a generator instance."""
-
-    def __init__(self, owner):
-        self.owner = owner
-
-    @staticmethod
-    def adaptive_rsi_threshold(
-        rsi_series, vol_series, k: float | None = None, window: int = 14
-    ):
-        """Weighted standard deviation based RSI thresholds."""
-        if rsi_series is None or vol_series is None:
-            return 30.0, 70.0
-        rsi_series = pd.Series(rsi_series).astype(float)
-        vol_series = pd.Series(vol_series).astype(float)
-        df = pd.DataFrame({"rsi": rsi_series, "vol": vol_series}).dropna()
-        if df.empty or len(df) < window:
-            return 30.0, 70.0
-        roll = df.tail(window)
-        weights = roll["vol"].to_numpy()
-        rsi_vals = roll["rsi"].to_numpy()
-        if not np.isfinite(weights).all() or np.allclose(weights, 0):
-            mean = rsi_vals.mean()
-            std = rsi_vals.std(ddof=0)
-        else:
-            mean = np.average(rsi_vals, weights=weights)
-            var = np.average((rsi_vals - mean) ** 2, weights=weights)
-            std = float(np.sqrt(var))
-        if k is None:
-            from .core import DEFAULT_RSI_K  # local import to avoid cycle
-
-            k = DEFAULT_RSI_K
-        lower = float(mean - k * std)
-        upper = float(mean + k * std)
-        return lower, upper
-
-    def base(
-        self,
-        atr,
-        adx,
-        funding=0,
-        *,
-        atr_4h=None,
-        adx_4h=None,
-        atr_d1=None,
-        adx_d1=None,
-        bb_width_chg=None,
-        channel_pos=None,
-        pred_vol=None,
-        pred_vol_4h=None,
-        pred_vol_d1=None,
-        vix_proxy=None,
-        base=None,
-        regime=None,
-        low_base=None,
-        reversal=False,
-        history_scores=None,
-    ):
-        """Compute dynamic threshold and reversal boost."""
-        params = self.owner.signal_params
-        dyn_p = self.owner.dynamic_th_params
-        base = params.base_th if base is None else base
-        low_base = params.low_base if low_base is None else low_base
-
-        if history_scores is not None:
-            scores = smooth_series(
-                history_scores,
-                window=getattr(self.owner, "smooth_window", 20),
-                alpha=getattr(self.owner, "smooth_alpha", 0.2),
-            )
-            limit = getattr(self.owner, "smooth_limit", 1.0)
-            if limit is not None:
-                scores = np.clip(scores, -limit, limit)
-            hist_base = _calc_history_base(
-                scores,
-                base,
-                params.quantile,
-                getattr(self.owner, "th_window", 60),
-                getattr(self.owner, "th_decay", 2.0),
-                0.12,
-            )
-        else:
-            hist_base = base
-
-        th = hist_base
-        atr_eff = abs(atr)
-        if atr_4h is not None:
-            atr_eff += 0.5 * abs(atr_4h)
-        if atr_d1 is not None:
-            atr_eff += 0.25 * abs(atr_d1)
-        th += min(dyn_p.atr_cap, atr_eff * dyn_p.atr_mult)
-
-        fund_eff = abs(funding)
-        if pred_vol is not None:
-            fund_eff += 0.5 * abs(pred_vol)
-        if pred_vol_4h is not None:
-            fund_eff += 0.25 * abs(pred_vol_4h)
-        if pred_vol_d1 is not None:
-            fund_eff += 0.15 * abs(pred_vol_d1)
-        if vix_proxy is not None:
-            fund_eff += 0.25 * abs(vix_proxy)
-        th += min(dyn_p.funding_cap, fund_eff * dyn_p.funding_mult)
-
-        adx_eff = abs(adx)
-        if adx_4h is not None:
-            adx_eff += 0.5 * abs(adx_4h)
-        if adx_d1 is not None:
-            adx_eff += 0.25 * abs(adx_d1)
-        th += min(dyn_p.adx_cap, adx_eff / dyn_p.adx_div)
-
-        if atr_eff == 0 and adx_eff == 0 and fund_eff == 0:
-            th = min(th, hist_base)
-
-        if regime is None:
-            regime = self.owner.classify_regime(adx, bb_width_chg, channel_pos)
-
-        if reversal:
-            th *= params.rev_th_mult
-
-        rev_boost = params.rev_boost
-        if regime == "trend":
-            th *= 1.05
-            rev_boost *= 0.8
-        elif regime == "range":
-            th *= 0.95
-            rev_boost *= 1.2
-
-        return max(th, low_base), rev_boost
+__all__ = [
+    "compute_dynamic_threshold",
+    "DynamicThresholdInput",
+    "ThresholdingDynamic",
+    "calc_dynamic_threshold",
+    "adaptive_rsi_threshold",
+]

--- a/tests/signal/test_dynamic_thresholds_basic.py
+++ b/tests/signal/test_dynamic_thresholds_basic.py
@@ -1,0 +1,74 @@
+import pytest
+
+from quant_trade.signal import (
+    DynamicThresholdInput,
+    SignalThresholdParams,
+    DynamicThresholdParams,
+    calc_dynamic_threshold,
+)
+
+
+def test_history_percentile_base():
+    params = SignalThresholdParams(base_th=0.05)
+    history = [0.1] * 100
+    data = DynamicThresholdInput(
+        atr=0,
+        adx=0,
+        history_scores=history,
+        base=0.05,
+        signal_params=params,
+    )
+    th, rb = calc_dynamic_threshold(data)
+    assert th == pytest.approx(0.1)
+    assert rb == pytest.approx(params.rev_boost)
+
+
+def test_atr_funding_stack():
+    sig_p = SignalThresholdParams(base_th=0, low_base=0)
+    dyn_p = DynamicThresholdParams()
+
+    atr_only = DynamicThresholdInput(
+        atr=0.02,
+        adx=0,
+        funding=0,
+        atr_4h=0.01,
+        atr_d1=0.01,
+        base=0,
+        low_base=0,
+        signal_params=sig_p,
+        dynamic_params=dyn_p,
+    )
+    fund_only = DynamicThresholdInput(
+        atr=0,
+        adx=0,
+        funding=0.01,
+        pred_vol=0.02,
+        pred_vol_4h=0.01,
+        pred_vol_d1=0.01,
+        vix_proxy=0.02,
+        base=0,
+        low_base=0,
+        signal_params=sig_p,
+        dynamic_params=dyn_p,
+    )
+    both = DynamicThresholdInput(
+        atr=0.02,
+        adx=0,
+        funding=0.01,
+        atr_4h=0.01,
+        atr_d1=0.01,
+        pred_vol=0.02,
+        pred_vol_4h=0.01,
+        pred_vol_d1=0.01,
+        vix_proxy=0.02,
+        base=0,
+        low_base=0,
+        signal_params=sig_p,
+        dynamic_params=dyn_p,
+    )
+    th_atr, _ = calc_dynamic_threshold(atr_only)
+    th_fund, _ = calc_dynamic_threshold(fund_only)
+    th_both, _ = calc_dynamic_threshold(both)
+    assert th_atr == pytest.approx(0.10)
+    assert th_fund == pytest.approx(0.08)
+    assert th_both == pytest.approx(th_atr + th_fund)


### PR DESCRIPTION
## Summary
- extract dynamic threshold logic into dynamic_thresholds module with new `calc_dynamic_threshold`
- use `calc_dynamic_threshold` in core dynamic threshold computation
- add basic tests for history quantile and ATR/Funding stacking

## Testing
- `pytest -q tests/signal/test_dynamic_thresholds_basic.py`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_689c097756bc832abe6e2df697e17cf8