### PR TITLE
refactor risk filters into multipliers and reasons

### DIFF
--- a/tests/signal/test_risk_filters_basic.py
+++ b/tests/signal/test_risk_filters_basic.py
@@ -1,0 +1,104 @@
+import pytest
+from collections import deque
+
+from quant_trade.tests.test_utils import make_dummy_rsg
+from quant_trade.signal import compute_dynamic_threshold
+from quant_trade.constants import RiskReason
+
+
+def test_oi_overheat_reason():
+    rsg = make_dummy_rsg()
+    rsg.risk_manager.calc_risk = lambda *a, **k: 0.0
+    cache = {
+        "history_scores": deque(),
+        "oi_change_history": deque(),
+        "_raw_history": {"1h": deque(maxlen=4), "d1": []},
+        "oi_overheat": True,
+    }
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
+    score_mult, pos_mult = rsg.risk_filters.compute_risk_multipliers(
+        fused_score=0.5,
+        logic_score=0.5,
+        env_score=0.0,
+        std_1h={},
+        std_4h={},
+        std_d1={},
+        raw_f1h={},
+        raw_f4h={},
+        raw_fd1={},
+        vol_preds={},
+        open_interest=None,
+        all_scores_list=None,
+        rev_dir=0,
+        cache=cache,
+        global_metrics=None,
+        symbol=None,
+        dyn_base=dyn_base,
+    )
+    reasons = rsg.risk_filters.collect_risk_reasons(
+        0.5, score_mult, pos_mult, cache
+    )
+    assert (score_mult, pos_mult) == (1.0, 1.0)
+    assert reasons == [RiskReason.OI_OVERHEAT.value]
+
+
+def test_crowding_conflict_reason(monkeypatch):
+    rsg = make_dummy_rsg()
+    rsg.filter_penalty_mode = True
+    rsg.penalty_factor = 0.5
+    rsg.risk_manager.calc_risk = lambda *a, **k: 0.0
+    cache = {
+        "history_scores": deque(),
+        "oi_change_history": deque(),
+        "_raw_history": {"1h": deque(maxlen=4), "d1": []},
+    }
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
+
+    def fake_crowding(
+        fused_score,
+        *,
+        base_th,
+        all_scores_list,
+        oi_chg,
+        cache,
+        vol_pred,
+        oi_overheat,
+        symbol,
+    ):
+        return fused_score, 2.0, None
+
+    monkeypatch.setattr(
+        rsg.risk_filters, "apply_crowding_protection", fake_crowding
+    )
+    score_mult, pos_mult = rsg.risk_filters.compute_risk_multipliers(
+        fused_score=1.0,
+        logic_score=1.0,
+        env_score=0.0,
+        std_1h={},
+        std_4h={},
+        std_d1={},
+        raw_f1h={},
+        raw_f4h={},
+        raw_fd1={},
+        vol_preds={},
+        open_interest=None,
+        all_scores_list=None,
+        rev_dir=0,
+        cache=cache,
+        global_metrics=None,
+        symbol=None,
+        dyn_base=dyn_base,
+    )
+    reasons = rsg.risk_filters.collect_risk_reasons(
+        1.0, score_mult, pos_mult, cache
+    )
+    assert score_mult == pytest.approx(1.0)
+    assert pos_mult == pytest.approx(0.5)
+    assert reasons == [RiskReason.CONFLICT_PENALTY.value]
+

--- a/tests/test_dynamic_min.py
+++ b/tests/test_dynamic_min.py
@@ -1,6 +1,7 @@
 import pytest
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.constants import RiskReason
+from quant_trade.signal import compute_dynamic_threshold
 
 
 def test_dynamic_min_risk_scaling():
@@ -80,6 +81,10 @@ def test_dyn_th_active_when_filters_off():
     rsg.dynamic_threshold = lambda *a, **k: (0.2, 0.0)
     rsg.detect_market_regime = lambda *a, **k: "range"
     cache = {"history_scores": rsg.history_scores, "_raw_history": {"1h": []}, "oi_change_history": []}
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.1,
         logic_score=0.1,
@@ -97,5 +102,6 @@ def test_dyn_th_active_when_filters_off():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
     assert res == (1.0, 1.0, [])

--- a/tests/test_penalty_mode.py
+++ b/tests/test_penalty_mode.py
@@ -4,6 +4,7 @@ from collections import deque
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.robust_signal_generator import SignalThresholdParams
 from quant_trade.constants import RiskReason
+from quant_trade.signal import compute_dynamic_threshold
 
 
 def make_cache():
@@ -25,6 +26,10 @@ def test_penalty_on_risk_filters():
     rsg.risk_manager.calc_risk = lambda *a, **k: 1.0
     cache = make_cache()
     raw_f1h = {"funding_rate_1h": -0.001}
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.5,
         logic_score=0.5,
@@ -42,6 +47,7 @@ def test_penalty_on_risk_filters():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
     assert res is not None
     score_mult, pos_mult, reasons = res

--- a/tests/test_risk_budget_threshold.py
+++ b/tests/test_risk_budget_threshold.py
@@ -8,6 +8,7 @@ from quant_trade.robust_signal_generator import (
     SignalThresholdParams,
 )
 from quant_trade.tests.test_utils import make_dummy_rsg
+from quant_trade.signal import compute_dynamic_threshold
 
 
 def test_risk_budget_threshold_basic():
@@ -26,6 +27,10 @@ def test_risk_budget_threshold_in_filter():
         "oi_change_history": rsg.oi_change_history,
         "_raw_history": {"1h": deque(maxlen=4)},
     }
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.04,
         logic_score=0.04,
@@ -43,12 +48,16 @@ def test_risk_budget_threshold_in_filter():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
     assert res is not None
     score_mult, pos_mult, reasons = res
     assert score_mult == 0.0
     assert pos_mult == 0.0
 
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res2 = rsg.risk_filters.apply_risk_filters(
         fused_score=0.06,
         logic_score=0.06,
@@ -66,6 +75,7 @@ def test_risk_budget_threshold_in_filter():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
     assert res2 is not None
     score_mult2, pos_mult2, reasons2 = res2
@@ -85,6 +95,10 @@ def test_history_quantile_threshold():
         "_raw_history": {"1h": deque(maxlen=4)},
     }
 
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res = rsg.risk_filters.apply_risk_filters(
         fused_score=0.02,
         logic_score=0.02,
@@ -102,6 +116,7 @@ def test_history_quantile_threshold():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
 
     assert res is not None
@@ -109,6 +124,9 @@ def test_history_quantile_threshold():
     assert score_mult == 0.0
     assert pos_mult == 0.0
 
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     res2 = rsg.risk_filters.apply_risk_filters(
         fused_score=0.06,
         logic_score=0.06,
@@ -126,6 +144,7 @@ def test_history_quantile_threshold():
         cache=cache,
         global_metrics=None,
         symbol=None,
+        dyn_base=dyn_base,
     )
 
     assert res2 is not None

--- a/tests/test_risk_conflict_oi_overheat.py
+++ b/tests/test_risk_conflict_oi_overheat.py
@@ -3,6 +3,7 @@ import pytest
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.robust_signal_generator import SignalThresholdParams
 from quant_trade.constants import RiskReason
+from quant_trade.signal import compute_dynamic_threshold
 from tests.test_overbought_oversold import base_inputs, make_cache
 
 
@@ -37,6 +38,10 @@ def test_funding_conflict_and_oi_overheat_finalization():
     raw_f1h_conflict = dict(raw_f1h)
     raw_f1h_conflict["funding_rate_1h"] = -0.0006
 
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     ret = rsg.risk_filters.apply_risk_filters(
         fused_score=fused_score,
         logic_score=risk_info["logic_score"],
@@ -54,6 +59,7 @@ def test_funding_conflict_and_oi_overheat_finalization():
         cache=cache,
         global_metrics=None,
         symbol="BTCUSDT",
+        dyn_base=dyn_base,
     )
     assert ret is not None
     score_mult, pos_mult, reasons = ret

--- a/tests/test_risk_threshold_warning.py
+++ b/tests/test_risk_threshold_warning.py
@@ -5,6 +5,7 @@ import pytest
 
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.robust_signal_generator import SignalThresholdParams
+from quant_trade.signal import compute_dynamic_threshold
 
 
 def test_nan_dynamic_risk_threshold(caplog):
@@ -17,6 +18,10 @@ def test_nan_dynamic_risk_threshold(caplog):
         "oi_change_history": deque(),
         "_raw_history": {"1h": deque(maxlen=4)},
     }
+    params = rsg.signal_params
+    dyn_base = compute_dynamic_threshold(
+        cache["history_scores"], params.window, params.dynamic_quantile
+    )
     with caplog.at_level(logging.WARNING):
         res = rsg.risk_filters.apply_risk_filters(
             fused_score=0.04,
@@ -35,6 +40,7 @@ def test_nan_dynamic_risk_threshold(caplog):
             cache=cache,
             global_metrics=None,
             symbol=None,
+            dyn_base=dyn_base,
         )
     assert res is not None
     score_mult, pos_mult, _ = res


### PR DESCRIPTION
## Summary
- split risk filter calculation into `compute_risk_multipliers` and `collect_risk_reasons`
- inject dynamic threshold via parameter and update `RobustSignalGenerator` risk checks
- add basic tests for OI overheat and crowding scenarios

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_689c0fd3bb90832aa475f25a412b34ab