### PR TITLE
refactor: extract position sizing helpers

### DIFF
--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -187,6 +187,7 @@ from .dynamic_thresholds import (
     calc_dynamic_threshold,
 )
 from .position_sizer import PositionSizerImpl
+from .position_sizing import calc_position_size
 
 
 @dataclass
@@ -2373,6 +2374,8 @@ class RobustSignalGenerator:
             ),
             consensus_all=risk_info.get("consensus_all", False),
         )
+
+        pos_size = calc_position_size(pos_size, self.max_position)
 
         pos_size, direction, zero_reason, penalties = self.position_sizer._apply_position_filters(
             pos_size,

--- a/quant_trade/signal/engine.py
+++ b/quant_trade/signal/engine.py
@@ -12,6 +12,7 @@ from .factor_scorer import FactorScorerImpl
 from .position_sizer import PositionSizerImpl
 from .predictor_adapter import PredictorAdapter
 from .risk_filters import RiskFiltersImpl
+from .position_sizing import calc_position_size
 
 
 def _to_float_dict(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -222,5 +223,10 @@ class SignalEngine:
             cache,
             ctx.get("symbol"),
             ts,
+        )
+        if result is None:
+            return None
+        result["position_size"] = calc_position_size(
+            result.get("position_size", 0.0), self.rsg.max_position
         )
         return _to_float_dict(result)

--- a/quant_trade/signal/position_sizer.py
+++ b/quant_trade/signal/position_sizer.py
@@ -8,6 +8,15 @@ import numpy as np
 from ..constants import RiskReason
 from .utils import sigmoid
 from quant_trade.utils import get_cfg_value
+from .position_sizing import (
+    calc_position_size,
+    compute_exit_multiplier as _compute_exit_multiplier,
+    compute_tp_sl as _compute_tp_sl,
+    _apply_risk_adjustment as apply_risk_adjustment,
+    _apply_low_volume_penalty as apply_low_vol_penalty,
+    _apply_vol_prediction_adjustment as apply_vol_pred_adj,
+    _adjust_min_pos_vol as adjust_min_pos_vol,
+)
 
 
 class PositionSizerImpl:
@@ -18,42 +27,11 @@ class PositionSizerImpl:
 
     def compute_exit_multiplier(self, vote: float, prev_vote: float, last_signal: int) -> float:
         """根据票数变化决定半退出或全平仓位系数"""
-        with self.rsg._lock:
-            exit_lag = self.rsg._exit_lag
-
-        exit_mult = 1.0
-        vote_sign = np.sign(vote)
-        prev_sign = np.sign(prev_vote)
-        if last_signal == 1:
-            if vote_sign == 1 and prev_vote > vote:
-                exit_mult = 0.5
-                exit_lag = 0
-            elif vote_sign <= 0 and prev_sign > 0:
-                exit_lag += 1
-                exit_mult = 0.0 if exit_lag >= self.rsg.exit_lag_bars else 0.5
-            else:
-                exit_lag = 0
-        elif last_signal == -1:
-            if vote_sign == -1 and prev_vote < vote:
-                exit_mult = 0.5
-                exit_lag = 0
-            elif vote_sign >= 0 and prev_sign < 0:
-                exit_lag += 1
-                exit_mult = 0.0 if exit_lag >= self.rsg.exit_lag_bars else 0.5
-            else:
-                exit_lag = 0
-        else:
-            exit_lag = 0
-
-        with self.rsg._lock:
-            self.rsg._exit_lag = exit_lag
-
-        return exit_mult
+        return _compute_exit_multiplier(self.rsg, vote, prev_vote, last_signal)
 
     def _apply_risk_adjustment(self, pos_size: float, risk_score: float) -> float:
         """根据风险评分调整仓位大小"""
-        risk_factor = math.exp(-self.rsg.risk_scale * risk_score)
-        return pos_size * risk_factor
+        return apply_risk_adjustment(pos_size, risk_score, self.rsg.risk_scale)
 
     def _apply_low_volume_penalty(
         self,
@@ -66,31 +44,25 @@ class PositionSizerImpl:
         consensus_all: bool,
     ) -> Tuple[float, bool]:
         """在低成交量环境下惩罚仓位, 返回是否触发标记"""
-        low_vol_flag = (
-            regime == "range"
-            and vol_ratio is not None
-            and vol_ratio < self.rsg.low_vol_ratio
-            and abs(fused_score) < base_th + 0.02
-            and not consensus_all
+        return apply_low_vol_penalty(
+            self.rsg,
+            pos_size,
+            regime=regime,
+            vol_ratio=vol_ratio,
+            fused_score=fused_score,
+            base_th=base_th,
+            consensus_all=consensus_all,
         )
-        if low_vol_flag:
-            pos_size *= 0.5
-        return pos_size, low_vol_flag
 
     def _apply_vol_prediction_adjustment(self, pos_size: float, vol_p: float | None) -> float:
         """根据预测波动率对仓位进行修正"""
-        if vol_p is not None:
-            pos_size *= max(0.4, 1 - min(0.6, vol_p))
-        return pos_size
+        return apply_vol_pred_adj(pos_size, vol_p)
 
     def _adjust_min_pos_vol(self, min_pos: float, atr: float | None, vol_p: float | None) -> float:
         """根据历史 ATR 或预测波动率调节仓位下限"""
-        vol_ref = 0.0
-        if vol_p is not None and np.isfinite(vol_p):
-            vol_ref = abs(vol_p)
-        elif atr is not None and np.isfinite(atr):
-            vol_ref = abs(atr)
-        return min_pos * (1 + self.rsg.min_pos_vol_scale * vol_ref)
+        return adjust_min_pos_vol(
+            min_pos, atr, vol_p, min_pos_vol_scale=self.rsg.min_pos_vol_scale
+        )
 
     def compute_tp_sl(
         self,
@@ -105,39 +77,17 @@ class PositionSizerImpl:
         regime: str | None = None,
     ):
         """计算止盈止损价格，可根据模型预测值微调"""
-        if direction == 0:
-            return None, None
-        if price is None or not np.isfinite(price):
-            return None, None
-        if price <= 0:
-            return None, None
-        if atr is None or not np.isfinite(atr):
-            return None, None
-        if atr == 0:
-            atr = 0.005 * price
-
-        cfg = getattr(self.rsg, "cfg", {})
-        max_sl_pct = get_cfg_value(cfg, "max_stop_loss_pct", 0.05)
-
-        if rise_pred is None:
-            rise_pred = 0.0
-        if drawdown_pred is None:
-            drawdown_pred = 0.0
-
-        if direction == 1:
-            max_sl = price * (1 - max_sl_pct)
-            tp0 = price * (1 + min(rise_pred, 0.10))
-            sl0 = price * (1 + max(drawdown_pred, -max_sl_pct))
-            tp = max(tp0, price * 1.02)
-            sl = min(sl0, max_sl)
-        else:
-            max_sl = price * (1 + max_sl_pct)
-            tp0 = price * (1 - min(rise_pred, 0.10))
-            sl0 = price * (1 - max(drawdown_pred, -max_sl_pct))
-            tp = min(tp0, price * 0.98)
-            sl = max(sl0, max_sl)
-
-        return float(tp), float(sl)
+        return _compute_tp_sl(
+            self.rsg,
+            price,
+            atr,
+            direction,
+            tp_mult=tp_mult,
+            sl_mult=sl_mult,
+            rise_pred=rise_pred,
+            drawdown_pred=drawdown_pred,
+            regime=regime,
+        )
 
     def _determine_direction(
         self,
@@ -294,7 +244,7 @@ class PositionSizerImpl:
         pos_size = base_size * sigmoid(confidence_factor)
         pos_size = self._apply_risk_adjustment(pos_size, risk_score)
         pos_size *= exit_mult
-        pos_size = min(pos_size, self.rsg.max_position)
+        pos_size = calc_position_size(pos_size, self.rsg.max_position)
         pos_size *= crowding_factor
         if direction == 0:
             pos_size = 0.0
@@ -317,5 +267,7 @@ class PositionSizerImpl:
         if self.rsg.risk_filters_enabled and pos_size < dynamic_min:
             pos_size = min(max(pos_size, dynamic_min), self.rsg.max_position)
             zero_reason = RiskReason.MIN_POS.value
+
+        pos_size = calc_position_size(pos_size, self.rsg.max_position)
 
         return pos_size, direction, tier, zero_reason

--- a/quant_trade/signal/position_sizing.py
+++ b/quant_trade/signal/position_sizing.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import numpy as np
+
+from .utils import sigmoid
+from quant_trade.utils import get_cfg_value
+
+
+def calc_position_size(strength: float, target_risk: float) -> float:
+    """根据信号强度计算目标仓位大小并按风险预算压缩。"""
+    return min(abs(strength), target_risk)
+
+
+def compute_exit_multiplier(rsg, vote: float, prev_vote: float, last_signal: int) -> float:
+    """根据票数变化决定半退出或全平仓位系数"""
+    with rsg._lock:
+        exit_lag = rsg._exit_lag
+
+    exit_mult = 1.0
+    vote_sign = np.sign(vote)
+    prev_sign = np.sign(prev_vote)
+    if last_signal == 1:
+        if vote_sign == 1 and prev_vote > vote:
+            exit_mult = 0.5
+            exit_lag = 0
+        elif vote_sign <= 0 and prev_sign > 0:
+            exit_lag += 1
+            exit_mult = 0.0 if exit_lag >= rsg.exit_lag_bars else 0.5
+        else:
+            exit_lag = 0
+    elif last_signal == -1:
+        if vote_sign == -1 and prev_vote < vote:
+            exit_mult = 0.5
+            exit_lag = 0
+        elif vote_sign >= 0 and prev_sign < 0:
+            exit_lag += 1
+            exit_mult = 0.0 if exit_lag >= rsg.exit_lag_bars else 0.5
+        else:
+            exit_lag = 0
+    else:
+        exit_lag = 0
+
+    with rsg._lock:
+        rsg._exit_lag = exit_lag
+
+    return exit_mult
+
+
+def _apply_risk_adjustment(pos_size: float, risk_score: float, risk_scale: float) -> float:
+    """根据风险评分调整仓位大小"""
+    risk_factor = math.exp(-risk_scale * risk_score)
+    return pos_size * risk_factor
+
+
+def _apply_low_volume_penalty(
+    rsg,
+    pos_size: float,
+    *,
+    regime: str,
+    vol_ratio: float | None,
+    fused_score: float,
+    base_th: float,
+    consensus_all: bool,
+) -> Tuple[float, bool]:
+    """在低成交量环境下惩罚仓位, 返回是否触发标记"""
+    low_vol_flag = (
+        regime == "range"
+        and vol_ratio is not None
+        and vol_ratio < rsg.low_vol_ratio
+        and abs(fused_score) < base_th + 0.02
+        and not consensus_all
+    )
+    if low_vol_flag:
+        pos_size *= 0.5
+    return pos_size, low_vol_flag
+
+
+def _apply_vol_prediction_adjustment(pos_size: float, vol_p: float | None) -> float:
+    """根据预测波动率对仓位进行修正"""
+    if vol_p is not None:
+        pos_size *= max(0.4, 1 - min(0.6, vol_p))
+    return pos_size
+
+
+def _adjust_min_pos_vol(
+    min_pos: float,
+    atr: float | None,
+    vol_p: float | None,
+    *,
+    min_pos_vol_scale: float,
+) -> float:
+    """根据历史 ATR 或预测波动率调节仓位下限"""
+    vol_ref = 0.0
+    if vol_p is not None and np.isfinite(vol_p):
+        vol_ref = abs(vol_p)
+    elif atr is not None and np.isfinite(atr):
+        vol_ref = abs(atr)
+    return min_pos * (1 + min_pos_vol_scale * vol_ref)
+
+
+def compute_tp_sl(
+    rsg,
+    price,
+    atr,
+    direction,
+    tp_mult: float = 1.5,
+    sl_mult: float = 1.0,
+    *,
+    rise_pred: float | None = None,
+    drawdown_pred: float | None = None,
+    regime: str | None = None,
+):
+    """计算止盈止损价格，可根据模型预测值微调"""
+    if direction == 0:
+        return None, None
+    if price is None or not np.isfinite(price):
+        return None, None
+    if price <= 0:
+        return None, None
+    if atr is None or not np.isfinite(atr):
+        return None, None
+    if atr == 0:
+        atr = 0.005 * price
+
+    cfg = getattr(rsg, "cfg", {})
+    max_sl_pct = get_cfg_value(cfg, "max_stop_loss_pct", 0.05)
+
+    if rise_pred is None:
+        rise_pred = 0.0
+    if drawdown_pred is None:
+        drawdown_pred = 0.0
+
+    if direction == 1:
+        max_sl = price * (1 - max_sl_pct)
+        tp0 = price * (1 + min(rise_pred, 0.10))
+        sl0 = price * (1 + max(drawdown_pred, -max_sl_pct))
+        tp = max(tp0, price * 1.02)
+        sl = min(sl0, max_sl)
+    else:
+        max_sl = price * (1 + max_sl_pct)
+        tp0 = price * (1 - min(rise_pred, 0.10))
+        sl0 = price * (1 - max(drawdown_pred, -max_sl_pct))
+        tp = min(tp0, price * 0.98)
+        sl = max(sl0, max_sl)
+
+    return float(tp), float(sl)

--- a/tests/signal/test_position_sizing_basic.py
+++ b/tests/signal/test_position_sizing_basic.py
@@ -1,0 +1,26 @@
+import pytest
+
+from quant_trade.tests.test_utils import make_dummy_rsg
+from quant_trade.signal.position_sizing import (
+    calc_position_size,
+    compute_exit_multiplier,
+    compute_tp_sl,
+)
+
+
+def test_position_size_and_tp_sl_basic():
+    rsg = make_dummy_rsg()
+    strength = 0.8
+    target = 0.2
+    base = calc_position_size(strength, target)
+    assert base == pytest.approx(min(abs(strength), target))
+
+    rsg._exit_lag = 0
+    rsg.exit_lag_bars = 2
+    mult = compute_exit_multiplier(rsg, 1.0, 2.0, 1)
+    size = base * mult
+    assert size == pytest.approx(base * 0.5)
+
+    tp, sl = compute_tp_sl(rsg, 100, 10, 1)
+    assert tp > 100
+    assert sl < 100


### PR DESCRIPTION
## Summary
- move exit multiplier, TP/SL and helper logic to new `position_sizing` module
- use `calc_position_size` for risk-budget-aware sizing in engine and core
- test basic position sizing and TP/SL computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c14876ef0832a809b61b7ef6ebd52