### PR TITLE
feat: refine position sizing with directional strength

### DIFF
--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -133,7 +133,12 @@ def generate_signal(
 
     # 6. 仓位与 TP/SL
     final_score = fused_score * score_mult
-    pos_size = position_sizing.calc_position_size(final_score, pos_mult)
+    pos_size = position_sizing.calc_position_size(
+        final_score,
+        base_th,
+        max_position=pos_mult,
+        min_exposure=0.2 * pos_mult,
+    )
     take_profit, stop_loss = None, None
 
     return {

--- a/quant_trade/signal/engine.py
+++ b/quant_trade/signal/engine.py
@@ -12,7 +12,6 @@ from .factor_scorer import FactorScorerImpl
 from .position_sizer import PositionSizerImpl
 from .predictor_adapter import PredictorAdapter
 from .risk_filters import RiskFiltersImpl
-from .position_sizing import calc_position_size
 
 
 def _to_float_dict(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -226,7 +225,7 @@ class SignalEngine:
         )
         if result is None:
             return None
-        result["position_size"] = calc_position_size(
+        result["position_size"] = min(
             result.get("position_size", 0.0), self.rsg.max_position
         )
         return _to_float_dict(result)

--- a/quant_trade/signal/position_sizer.py
+++ b/quant_trade/signal/position_sizer.py
@@ -9,7 +9,6 @@ from ..constants import RiskReason
 from .utils import sigmoid
 from quant_trade.utils import get_cfg_value
 from .position_sizing import (
-    calc_position_size,
     compute_exit_multiplier as _compute_exit_multiplier,
     compute_tp_sl as _compute_tp_sl,
     _apply_risk_adjustment as apply_risk_adjustment,
@@ -244,7 +243,7 @@ class PositionSizerImpl:
         pos_size = base_size * sigmoid(confidence_factor)
         pos_size = self._apply_risk_adjustment(pos_size, risk_score)
         pos_size *= exit_mult
-        pos_size = calc_position_size(pos_size, self.rsg.max_position)
+        pos_size = min(pos_size, self.rsg.max_position)
         pos_size *= crowding_factor
         if direction == 0:
             pos_size = 0.0
@@ -268,6 +267,6 @@ class PositionSizerImpl:
             pos_size = min(max(pos_size, dynamic_min), self.rsg.max_position)
             zero_reason = RiskReason.MIN_POS.value
 
-        pos_size = calc_position_size(pos_size, self.rsg.max_position)
+        pos_size = min(pos_size, self.rsg.max_position)
 
         return pos_size, direction, tier, zero_reason

--- a/tests/signal/test_position_sizing_basic.py
+++ b/tests/signal/test_position_sizing_basic.py
@@ -6,14 +6,34 @@ from quant_trade.signal.position_sizing import (
     compute_exit_multiplier,
     compute_tp_sl,
 )
+from quant_trade.signal.utils import sigmoid_dir
 
 
 def test_position_size_and_tp_sl_basic():
     rsg = make_dummy_rsg()
-    strength = 0.8
-    target = 0.2
-    base = calc_position_size(strength, target)
-    assert base == pytest.approx(min(abs(strength), target))
+    fused_score = 0.8
+    base_th = 0.2
+    max_pos = 0.2
+    base = calc_position_size(
+        fused_score,
+        base_th,
+        max_position=max_pos,
+        gamma=0.5,
+    )
+    strength = sigmoid_dir(fused_score, base_th, 0.5)
+    assert base == pytest.approx(abs(strength) * max_pos)
+
+    weak_score = 0.25
+    base2 = calc_position_size(
+        weak_score,
+        base_th,
+        max_position=max_pos,
+        gamma=0.5,
+        min_exposure=0.2 * max_pos,
+    )
+    strength_weak = sigmoid_dir(weak_score, base_th, 0.5)
+    target_risk = abs(strength_weak) * max_pos
+    assert base2 == pytest.approx(max(target_risk, 0.2 * max_pos))
 
     rsg._exit_lag = 0
     rsg.exit_lag_bars = 2


### PR DESCRIPTION
## Summary
- use `sigmoid_dir` to convert fused signal into directional strength and risk-based size
- support CVaR/vol constraints with minimum exposure safeguard
- update signal generation to consume new position sizing API

## Testing
- `pytest -q tests/signal/test_position_sizing_basic.py`
- `pytest -q tests` *(fails: ImportError cannot import name 'adjust_score' from 'quant_trade.robust_signal_generator')*

------
https://chatgpt.com/codex/tasks/task_e_689c204c97c0832ab14d7100955e54e4