### PR TITLE
feat: extend voting model features and export meta

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -18,6 +18,7 @@ from .fusion_rule import FusionRuleBased
 from .risk_filters import RiskFiltersImpl
 from .position_sizer import PositionSizerImpl
 from .position_sizing import calc_position_size
+from .voting_model import VotingModel
 
 try:  # optional
     from .risk_filters import compute_risk_multipliers
@@ -42,6 +43,7 @@ __all__ = [
     "compute_dynamic_threshold",
     "calc_dynamic_threshold",
     "calc_position_size",
+    "VotingModel",
 ]
 if compute_risk_multipliers is not None:
     __all__.append("compute_risk_multipliers")

--- a/quant_trade/signal/voting_model.py
+++ b/quant_trade/signal/voting_model.py
@@ -22,10 +22,11 @@ exactly.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+import json
 import joblib
 import numpy as np
 import pandas as pd
@@ -41,6 +42,9 @@ class VotingModel:
     """Wrapper around a scikit-learn classifier."""
 
     model: object
+    feature_cols: list[str] = field(
+        default_factory=lambda: VotingModel.FEATURE_COLS  # type: ignore[name-defined]
+    )
 
     FEATURE_COLS = [
         "ai_dir",
@@ -49,6 +53,14 @@ class VotingModel:
         "trend_dir",
         "confirm_dir",
         "ob_dir",
+        "abs_ai_score",
+        "abs_momentum",
+        "consensus_all",
+        "ic_weight",
+        "abs_score_minus_base_th",
+        "confirm_15m",
+        "short_mom",
+        "ob_imb",
     ]
 
     @classmethod
@@ -57,6 +69,7 @@ class VotingModel:
         data: pd.DataFrame,
         *,
         model_type: str = "logistic",
+        feature_cols: Iterable[str] | None = None,
         **kwargs,
     ) -> "VotingModel":
         """Train a voting model.
@@ -68,32 +81,42 @@ class VotingModel:
             ``1`` denotes long and ``0`` denotes short.
         model_type:
             Either ``"logistic"`` or ``"gbdt"``.
+        feature_cols:
+            Feature columns used for training.  If ``None`` the class level
+            :attr:`FEATURE_COLS` will be used.
         kwargs:
             Extra keyword arguments passed to the scikit-learn estimator.
         """
 
-        X = data[cls.FEATURE_COLS].values
+        cols = list(feature_cols) if feature_cols is not None else list(cls.FEATURE_COLS)
+        missing = [c for c in cols + ["label"] if c not in data.columns]
+        if missing:
+            raise ValueError(f"训练数据缺少列: {', '.join(missing)}")
+
+        X = data[cols].values
         y = data["label"].values
         if model_type == "gbdt":
             est = GradientBoostingClassifier(**kwargs)
         else:
             est = LogisticRegression(**kwargs)
         est.fit(X, y)
-        return cls(est)
+        return cls(est, cols)
 
     def save(self, path: Path = DEFAULT_MODEL_PATH) -> None:
         """Persist model to ``path``."""
 
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        joblib.dump(self.model, path)
+        joblib.dump({"model": self.model, "feature_cols": self.feature_cols}, path)
 
     @classmethod
     def load(cls, path: Path = DEFAULT_MODEL_PATH) -> "VotingModel":
         """Load a trained model from ``path``."""
 
-        model = joblib.load(path)
-        return cls(model)
+        obj = joblib.load(path)
+        if isinstance(obj, dict) and "model" in obj:
+            return cls(obj["model"], obj.get("feature_cols", cls.FEATURE_COLS))
+        return cls(obj)
 
     def predict_proba(self, X: Iterable[Iterable[float]]) -> np.ndarray:
         """Return probability of positive class for ``X``."""
@@ -119,10 +142,12 @@ def safe_load(path: Path = DEFAULT_MODEL_PATH) -> VotingModel | None:
     """Safely load a model; return ``None`` if loading fails."""
 
     try:
-        model = joblib.load(path)
+        obj = joblib.load(path)
     except Exception:
         return None
-    return VotingModel(model)
+    if isinstance(obj, dict) and "model" in obj:
+        return VotingModel(obj["model"], obj.get("feature_cols", VotingModel.FEATURE_COLS))
+    return VotingModel(obj)
 
 
 def _main():  # pragma: no cover - simple CLI
@@ -141,12 +166,39 @@ def _main():  # pragma: no cover - simple CLI
         default=str(DEFAULT_MODEL_PATH),
         help="输出模型文件路径",
     )
+    parser.add_argument(
+        "--features",
+        default=",".join(VotingModel.FEATURE_COLS),
+        help="逗号分隔的特征列, 默认使用内置配置",
+    )
+    parser.add_argument("--start-date", help="训练开始日期", default=None)
+    parser.add_argument("--end-date", help="训练结束日期", default=None)
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="投票阈值, 将写入 meta.json",
+    )
     args = parser.parse_args()
 
+    feature_cols = [c.strip() for c in args.features.split(",") if c.strip()]
     df = pd.read_csv(args.data)
-    vm = VotingModel.train(df, model_type=args.model)
-    vm.save(Path(args.out))
-    print(f"model saved to {args.out}")
+    vm = VotingModel.train(df, model_type=args.model, feature_cols=feature_cols)
+    out_path = Path(args.out)
+    vm.save(out_path)
+
+    meta = {
+        "feature_cols": feature_cols,
+        "train_start": args.start_date,
+        "train_end": args.end_date,
+        "threshold": args.threshold,
+        "model_type": args.model,
+    }
+    meta_path = out_path.with_name("meta.json")
+    with meta_path.open("w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False, indent=2)
+
+    print(f"model saved to {out_path}, meta saved to {meta_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/tests/test_voting_model.py
+++ b/tests/test_voting_model.py
@@ -12,15 +12,24 @@ def test_voting_model_train_and_predict(tmp_path):
             "trend_dir": [1, -1, 1, -1],
             "confirm_dir": [1, -1, 1, -1],
             "ob_dir": [0, 0, 1, -1],
+            "abs_ai_score": [0.1, 0.2, 0.3, 0.4],
+            "abs_momentum": [0.5, 0.6, 0.7, 0.8],
+            "consensus_all": [1, 1, 1, 1],
+            "ic_weight": [0.9, 0.8, 0.7, 0.6],
+            "abs_score_minus_base_th": [0.2, 0.1, 0.3, 0.4],
+            "confirm_15m": [1, -1, 1, -1],
+            "short_mom": [0.2, 0.3, 0.4, 0.5],
+            "ob_imb": [0.1, 0.2, 0.3, 0.4],
             "label": [1, 0, 1, 0],
         }
     )
     model = VotingModel.train(data)
-    prob = model.predict_proba([[1, 1, 1, 1, 1, 0]])[0, 1]
+    sample = [[1, 1, 1, 1, 1, 0, 0.1, 0.5, 1, 0.9, 0.2, 1, 0.2, 0.1]]
+    prob = model.predict_proba(sample)[0, 1]
     assert 0.0 <= prob <= 1.0
 
     path = tmp_path / "vm.pkl"
     model.save(path)
     loaded = VotingModel.load(path)
-    prob2 = loaded.predict_proba([[1, 1, 1, 1, 1, 0]])[0, 1]
+    prob2 = loaded.predict_proba(sample)[0, 1]
     assert prob == prob2


### PR DESCRIPTION
## Summary
- expand voting model FEATURE_COLS with new signals
- validate feature columns and save meta information during training
- expose VotingModel in signal package and update tests

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'adjust_score' ...)*
- `pytest tests/test_voting_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3a0847b4832ab4b6e677ae4c1436