### PR TITLE
完善投票阈值配置说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ market_phase:
 -   阈值相关配置已整合为 `SignalThresholdParams`，方便统一管理。
 -   新增 `dynamic_threshold` 配置项，可自定义 ATR、ADX 与 funding 对阈值的影响系数及上限。
 -   新增 `smooth_window`、`smooth_alpha` 与 `smooth_limit` 参数，用于平滑最近得分，减少噪声影响。
+-   `vote_system.prob_th` 为基础概率阈值（默认 0.5），`prob_margin` 用于弱票判定（如 0.08 表示 `0.5±0.08`），`strong_prob_th` 与 `_compute_vote` 结合使用以判定强票。
 -   新增 `risk_budget_threshold` 函数，可依据历史波动率或换手率分布计算风险阈值：
 
 ```python

--- a/quant_trade/config_schema.py
+++ b/quant_trade/config_schema.py
@@ -20,9 +20,13 @@ class VoteSystem(BaseModel):
     weight_ai: float = 3
     strong_min: int = 2
     conf_min: float = 0.25
-    prob_th: float = 0.5
-    prob_margin: float = 0.1
-    strong_prob_th: float = 0.8
+    prob_th: float = Field(0.5, description="基础概率阈值")
+    prob_margin: float = Field(
+        0.08, description="用于弱票判定的概率边际，如0.08表示0.5±0.08"
+    )
+    strong_prob_th: float = Field(
+        0.8, description="与 _compute_vote 结合使用的强票概率阈值"
+    )
     ai_dir_eps: float = 0.10
 
 

--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -24,8 +24,8 @@ class RobustSignalGeneratorConfig:
     feature_cols_1h: list[str] = field(default_factory=list)
     feature_cols_4h: list[str] = field(default_factory=list)
     feature_cols_d1: list[str] = field(default_factory=list)
-    prob_margin: float = 0.1
-    strong_prob_th: float = 0.8
+    prob_margin: float = 0.08
+    strong_prob_th: float = 0.8  # 与 _compute_vote 配合判断强票
     config_path: str | Path | None = None
 
     @classmethod
@@ -39,7 +39,7 @@ class RobustSignalGeneratorConfig:
             feature_cols_1h=cfg.get("feature_cols_1h", []),
             feature_cols_4h=cfg.get("feature_cols_4h", []),
             feature_cols_d1=cfg.get("feature_cols_d1", []),
-            prob_margin=cfg.get("prob_margin", 0.1),
+            prob_margin=cfg.get("prob_margin", 0.08),
             strong_prob_th=cfg.get("strong_prob_th", 0.8),
             config_path=cfg_path,
         )

--- a/quant_trade/utils/config.yaml
+++ b/quant_trade/utils/config.yaml
@@ -573,6 +573,9 @@ vote_system:
 #  weight_ai: 2          # 已由 vote_weights.ai 定义
   strong_min: 2
   conf_min: 0.25
+  prob_th: 0.5            # 基础概率阈值
+  prob_margin: 0.08       # 弱票判定范围，如 0.5±0.08
+  strong_prob_th: 0.8     # 与 _compute_vote 结合使用的强票阈值
   ai_dir_eps: 0.10
 vote_weights:
   ai: 2


### PR DESCRIPTION
## Summary
- 补充 VoteSystem 配置字段说明，新增弱票判定范围
- 同步 robust_signal_generator 默认值与配置文件
- 在 README 中记录投票阈值参数用法

## Testing
- `pytest -q tests` *(failed: ImportError: cannot import name 'adjust_score'...)*

------
https://chatgpt.com/codex/tasks/task_e_689c493d9a14832a902bcf1e1d67cc51