### PR TITLE
feat: harmonize risk reason enums

### DIFF
--- a/quant_trade/constants.py
+++ b/quant_trade/constants.py
@@ -4,17 +4,19 @@ from enum import StrEnum
 class RiskReason(StrEnum):
     """风险过滤或归零原因枚举"""
 
-    NO_DIRECTION = "no_direction"
-    VOL_RATIO = "vol_ratio"
-    MIN_POS = "min_pos"
-    VOTE_FILTER = "vote_filter"
-    FUNDING_CONFLICT = "funding_conflict"
-    CONFLICT_FILTER = "conflict_filter"
-    VOTE_PENALTY = "vote_penalty"
-    FUNDING_PENALTY = "funding_penalty"
-    CONFLICT_PENALTY = "conflict_penalty"
-    RISK_LIMIT = "risk_limit"
-    OI_OVERHEAT = "oi_overheat"
+    NO_DIRECTION = "NO_DIRECTION"
+    VOL_RATIO = "VOL_RATIO"
+    MIN_POS = "MIN_POS"
+    VOTE_FILTER = "VOTE_FILTER"
+    FUNDING_CONFLICT = "FUNDING_CONFLICT"
+    CONFLICT_FILTER = "CONFLICT_FILTER"
+    VOTE_PENALTY = "VOTE_PENALTY"
+    FUNDING_PENALTY = "FUNDING_PENALTY"
+    CONFLICT_PENALTY = "CONFLICT_PENALTY"
+    CROWDING_FILTER = "CROWDING_FILTER"
+    CROWDING_PENALTY = "CROWDING_PENALTY"
+    RISK_LIMIT = "RISK_LIMIT"
+    OI_OVERHEAT = "OI_OVERHEAT"
 
 
 # 旧名称的兼容别名

--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -149,7 +149,9 @@ class RobustSignalGenerator:
 
         model_path: Path | None = None
         if self.cfg:
-            mp = self.cfg.model_paths.get("voting_model")
+            mp = getattr(self.cfg, "model_paths", None)
+            if mp is None and isinstance(self.cfg, Mapping):
+                mp = self.cfg.get("model_paths")
             if isinstance(mp, Mapping):
                 first = next(iter(mp.values()), None)
                 if first is not None:
@@ -196,9 +198,16 @@ class RobustSignalGenerator:
             direction = 1 if prob >= 0.5 else -1
             vote = direction * confidence
 
-        prob_margin = self.cfg.prob_margin if self.cfg else 0.0
+        prob_margin = 0.0
+        strong_prob_th = 1.0
+        if self.cfg:
+            if isinstance(self.cfg, Mapping):
+                prob_margin = self.cfg.get("prob_margin", 0.0)
+                strong_prob_th = self.cfg.get("strong_prob_th", 1.0)
+            else:
+                prob_margin = getattr(self.cfg, "prob_margin", 0.0)
+                strong_prob_th = getattr(self.cfg, "strong_prob_th", 1.0)
         weak_vote = 0.5 - prob_margin <= prob <= 0.5 + prob_margin
-        strong_prob_th = self.cfg.strong_prob_th if self.cfg else 1.0
         strong_confirm = confidence >= strong_prob_th
 
         return {
@@ -356,6 +365,7 @@ class RobustSignalGenerator:
             min_exposure=min_pos,
         )
 
+        pos_size = max(min_pos, min(pos_size, self.max_position))
         pos_size *= pos_mult
 
         vol_ratio = raw_f1h.get("vol_ma_ratio_1h")
@@ -380,8 +390,6 @@ class RobustSignalGenerator:
 
         if direction == 0:
             pos_size = 0.0
-        else:
-            pos_size = max(min_pos, min(pos_size, self.max_position))
 
         price = raw_f1h.get("close")
         atr = raw_f1h.get("atr_pct_1h")

--- a/quant_trade/signal/dynamic_thresholds.py
+++ b/quant_trade/signal/dynamic_thresholds.py
@@ -20,6 +20,21 @@ class SignalThresholdParams:
     quantile: float = 0.8
     rev_boost: float = 0.0
     rev_th_mult: float = 1.0
+    window: int = 60
+    dynamic_quantile: float = 0.8
+
+    @classmethod
+    def from_cfg(cls, cfg: Mapping[str, Any]) -> "SignalThresholdParams":
+        """Create params from configuration mapping."""
+        return cls(
+            base_th=cfg.get("base_th", 0.0),
+            low_base=cfg.get("low_base", 0.0),
+            quantile=cfg.get("quantile", 0.8),
+            rev_boost=cfg.get("rev_boost", 0.0),
+            rev_th_mult=cfg.get("rev_th_mult", 1.0),
+            window=cfg.get("window", 60),
+            dynamic_quantile=cfg.get("dynamic_quantile", cfg.get("quantile", 0.8)),
+        )
 
 
 @dataclass

--- a/quant_trade/signal/risk_filters.py
+++ b/quant_trade/signal/risk_filters.py
@@ -321,9 +321,9 @@ class RiskFiltersImpl:
             reasons.append(RiskReason.RISK_LIMIT.value)
         if self.last_crowding_factor < 0 or self.last_crowding_factor > core.crowding_limit:
             reasons.append(
-                RiskReason.CONFLICT_PENALTY.value
+                RiskReason.CROWDING_PENALTY.value
                 if core.filter_penalty_mode
-                else RiskReason.CONFLICT_FILTER.value
+                else RiskReason.CROWDING_FILTER.value
             )
         return reasons
 

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -59,6 +59,7 @@ def make_dummy_rsg():
     rsg.volume_ratio_history = deque([0.8, 1.0, 1.2], maxlen=500)
     rsg.risk_filters_enabled = True
     rsg.dynamic_threshold_enabled = True
+    rsg.direction_filters_enabled = True
     rsg.enable_factor_breakdown = True
     rsg.cycle_weight = {'strong': 1.0, 'weak': 1.0, 'opposite': 1.0}
     rsg.smooth_window = 20

--- a/tests/signal/test_risk_filters_basic.py
+++ b/tests/signal/test_risk_filters_basic.py
@@ -100,5 +100,5 @@ def test_crowding_conflict_reason(monkeypatch):
     )
     assert score_mult == pytest.approx(1.0)
     assert pos_mult == pytest.approx(0.5)
-    assert reasons == [RiskReason.CONFLICT_PENALTY.value]
+    assert reasons == [RiskReason.CROWDING_PENALTY.value]
 


### PR DESCRIPTION
## Summary
- standardize `RiskReason` enum values to uppercase and add crowding members
- handle crowding penalties in risk filters and expose direction filters in test helpers
- support config-driven threshold params and robust signal config fallbacks

## Testing
- `pytest -q tests/signal/test_risk_filters_basic.py tests/test_penalty_mode.py tests/test_risk_conflict_oi_overheat.py`

------
https://chatgpt.com/codex/tasks/task_e_689c86eebe7c832ab7a3e85b914c5559