### PR TITLE
feat: expose risk metrics in signal details

### DIFF
--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -57,6 +57,20 @@ def test_dynamic_threshold_basic():
     assert th == pytest.approx(0.08)
 
 
+def test_generate_signal_exposes_risk_fields():
+    """``generate_signal`` 应返回风险相关的详细字段。"""
+    rsg = make_dummy_rsg()
+    res = rsg.generate_signal({}, {}, {})
+    details = res["details"]
+    for key in ("crowding_factor", "oi_threshold", "risk_score", "base_th", "flip", "cooldown"):
+        assert key in details
+    assert details["crowding_factor"] >= 0
+    assert details["risk_score"] >= 0
+    assert details["base_th"] == pytest.approx(0.0)
+    assert details["flip"] is False
+    assert details["cooldown"] == 0
+
+
 def test_get_dynamic_oi_threshold():
     rsg = make_dummy_rsg()
     rsg.oi_change_history.extend([0.1]*80 + [0.6]*20)


### PR DESCRIPTION
## Summary
- expose cached risk metrics via `get_last_metrics` and module `compute_risk_multipliers`
- include crowding and threshold details in generated signal output
- test that signal details now carry risk-related fields

## Testing
- `pytest tests/test_signal_generator.py::test_generate_signal_exposes_risk_fields -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9d9fdc68832aafa0fce8338c42d1