### PR TITLE
feat: add json signal logger

### DIFF
--- a/quant_trade/json_logger.py
+++ b/quant_trade/json_logger.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from datetime import datetime
+from typing import Any, Mapping
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+LOG_DIR = BASE_DIR / "logs"
+
+def log_signal(record: Mapping[str, Any]) -> None:
+    """Append a trading signal record to a JSONL file.
+
+    The file is named ``signal_YYYYMMDD.jsonl`` under the ``logs`` directory.
+    ``record`` must contain ``open_time`` field which determines the filename.
+    """
+    ts = record.get("open_time")
+    if ts is None:
+        dt = pd.Timestamp.utcnow()
+    else:
+        dt = pd.to_datetime(ts)
+    LOG_DIR.mkdir(exist_ok=True)
+    fname = LOG_DIR / f"signal_{dt.strftime('%Y%m%d')}.jsonl"
+    with open(fname, "a", encoding="utf-8") as f:
+        json.dump(record, f, ensure_ascii=False, default=str)
+        f.write("\n")

--- a/tests/test_signal_json_logging.py
+++ b/tests/test_signal_json_logging.py
@@ -1,0 +1,83 @@
+import json
+import random
+import pandas as pd
+
+from quant_trade import json_logger
+import quant_trade.backtester as bt
+
+
+def test_signal_json_logging(monkeypatch, tmp_path):
+    # Redirect logs to temporary directory
+    monkeypatch.setattr(json_logger, "LOG_DIR", tmp_path / "logs")
+
+    # Minimal configuration and stubs
+    monkeypatch.setattr(bt, "load_config", lambda: {})
+    monkeypatch.setattr(bt, "connect_mysql", lambda cfg: None)
+    monkeypatch.setattr(bt, "FEATURE_COLS_1H", [])
+    monkeypatch.setattr(bt, "FEATURE_COLS_4H", [])
+    monkeypatch.setattr(bt, "FEATURE_COLS_D1", [])
+    monkeypatch.setattr(bt, "calc_features_raw", lambda df, period: pd.DataFrame(index=df.index))
+    monkeypatch.setattr(bt, "simulate_trades", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(pd.DataFrame, "to_csv", lambda *a, **k: None)
+
+    times = pd.date_range("2024-01-01", periods=11, freq="H")
+    df = pd.DataFrame({
+        "symbol": ["BTCUSDT"] * 11,
+        "open_time": times,
+        "close_time": times + pd.Timedelta(hours=1),
+        "open": [1] * 11,
+        "high": [1] * 11,
+        "low": [1] * 11,
+        "close": [1] * 11,
+        "volume": [1] * 11,
+    })
+
+    def fake_read_sql(sql, engine, params=None, parse_dates=None):
+        if "MAX(open_time" in sql:
+            return pd.DataFrame({"end_time": [times[-1]]})
+        return df
+
+    monkeypatch.setattr(bt.pd, "read_sql", fake_read_sql)
+
+    class DummyRSG:
+        def __init__(self, cfg):
+            pass
+
+        def update_ic_scores(self, df, group_by=None):
+            pass
+
+        def generate_signal_batch(self, f1, f4, fd):
+            results = []
+            for i in range(len(f1)):
+                results.append(
+                    {
+                        "signal": 1,
+                        "score": float(i),
+                        "position_size": 0.5,
+                        "take_profit": None,
+                        "stop_loss": None,
+                        "details": {
+                            "penalties": ["p1"],
+                            "score_mult": 0.8,
+                            "pos_mult": 0.6,
+                            "base_th": 0.1,
+                        },
+                    }
+                )
+            return results
+
+    monkeypatch.setattr(bt, "RobustSignalGenerator", DummyRSG)
+
+    bt.run_backtest(recent_days=1)
+
+    log_file = json_logger.LOG_DIR / f"signal_{times[1].strftime('%Y%m%d')}.jsonl"
+    assert log_file.exists()
+    with open(log_file, "r", encoding="utf-8") as f:
+        records = [json.loads(line) for line in f]
+
+    sample = random.sample(records, 5)
+    for rec in sample:
+        assert "reasons" in rec
+        assert "score_mult" in rec
+        assert "pos_mult" in rec
+        assert "base_th" in rec


### PR DESCRIPTION
## Summary
- implement JSONL logger for signals
- log signal details including multipliers and thresholds during backtests
- add test ensuring JSON logging records required fields

## Testing
- `pytest -q tests` *(fails: ImportError missing adjust_score, PeriodFeatures, smooth_score, risk_budget_threshold, Signal, softmax)*
- `python quant_trade/backtester.py --recent-days 1` *(fails: AttributeError: partially initialized module 'logging')*

------
https://chatgpt.com/codex/tasks/task_e_689ca63ef43c832aa2100b32f5acc938