### PR TITLE
feat: add batch factor scoring utilities

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -1,7 +1,7 @@
 """Signal generation subpackage exports."""
 
 from .core import generate_signal
-from .features_to_scores import get_factor_scores
+from .features_to_scores import get_factor_scores, get_factor_scores_batch
 from .ai_inference import get_period_ai_scores, get_reg_predictions
 from .multi_period_fusion import fuse_scores
 from .dynamic_thresholds import (
@@ -28,6 +28,7 @@ except Exception:  # pragma: no cover
 __all__ = [
     "generate_signal",
     "get_factor_scores",
+    "get_factor_scores_batch",
     "get_period_ai_scores",
     "get_reg_predictions",
     "fuse_scores",

--- a/tests/signal/test_features_to_scores_batch.py
+++ b/tests/signal/test_features_to_scores_batch.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from quant_trade.utils.lru import LRU
+from quant_trade.robust_signal_generator import RobustSignalGenerator
+from quant_trade.signal.features_to_scores import get_factor_scores_batch
+
+
+def make_rsg():
+    rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg._factor_cache = LRU(300)
+    rsg._ai_score_cache = LRU(300)
+    rsg.get_feat_value = lambda row, key, default=0: row.get(key, default)
+    rsg._make_cache_key = lambda features, period: (period, tuple(sorted(features.items())))
+    return rsg
+
+
+def test_batch_list_mapping():
+    rsg = make_rsg()
+    feats = [
+        {"rsi_1h": 40, "macd_hist_1h": 0},
+        {"rsi_1h": 60, "macd_hist_1h": 0.02},
+    ]
+    scores = get_factor_scores_batch(rsg, feats, "1h")
+    assert scores[1]["momentum"] > scores[0]["momentum"]
+
+
+def test_batch_structured_array():
+    rsg = make_rsg()
+    arr = np.array(
+        [(40, 0.0), (60, 0.02)],
+        dtype=[("rsi_1h", "f4"), ("macd_hist_1h", "f4")],
+    )
+    scores = get_factor_scores_batch(rsg, arr, "1h")
+    assert scores[1]["momentum"] > scores[0]["momentum"]
+

--- a/tests/test_rsg_batch_scoring.py
+++ b/tests/test_rsg_batch_scoring.py
@@ -1,0 +1,28 @@
+from quant_trade.robust_signal_generator import RobustSignalGenerator
+from quant_trade.signal import features_to_scores
+from quant_trade.utils.lru import LRU
+
+
+def test_rsg_generate_signal_batch_calls_vectorized(monkeypatch):
+    rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg._factor_cache = LRU(300)
+    rsg._ai_score_cache = LRU(300)
+
+    called = {"1h": 0, "4h": 0, "d1": 0}
+
+    def fake_batch(core, feats, period):
+        called[period] += 1
+        return [{} for _ in feats]
+
+    monkeypatch.setattr(features_to_scores, "get_factor_scores_batch", fake_batch)
+
+    def stub_generate_signal(f1, f4, fd, *a, **k):
+        return {}
+
+    rsg.generate_signal = stub_generate_signal
+
+    feats = [{}, {}]
+    rsg.generate_signal_batch(feats, feats, feats)
+
+    assert called["1h"] == 1 and called["4h"] == 1 and called["d1"] == 1
+

--- a/tests/test_signal_engine_batch.py
+++ b/tests/test_signal_engine_batch.py
@@ -1,0 +1,33 @@
+import types
+
+from quant_trade.signal.engine import SignalEngine
+from quant_trade.robust_signal_generator import RobustSignalGenerator
+
+
+def test_engine_run_batch_dispatch():
+    rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    called = {}
+
+    def fake_batch(f1, f4, fd, f15=None, symbols=None, **kwargs):
+        called["called"] = True
+        return [{"id": row["id"]} for row in f1]
+
+    rsg.generate_signal_batch = fake_batch
+
+    engine = SignalEngine(
+        rsg,
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+        types.SimpleNamespace(),
+    )
+
+    ctx = {
+        "features_1h": [{"id": 1}, {"id": 2}],
+        "features_4h": [{}, {}],
+        "features_d1": [{}, {}],
+    }
+    res = engine.run(ctx)
+    assert called.get("called")
+    assert [r["id"] for r in res] == [1, 2]
+


### PR DESCRIPTION
## Summary
- support vectorized factor scoring with `get_factor_scores_batch`
- pre-compute batch factor scores in RobustSignalGenerator
- SignalEngine dispatches to batch signal generation when receiving feature batches
- add tests for batch factor scoring path

## Testing
- `pytest -q tests` *(fails: AttributeError: 'RobustSignalGenerator' object has no attribute 'eth_dom_history', KeyError: 'env', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689d3559b3e4832a983ec4f0b087a847