### PR TITLE
feat: add batch AI score inference

### DIFF
--- a/scripts/benchmark_ai_batch.py
+++ b/scripts/benchmark_ai_batch.py
@@ -1,0 +1,33 @@
+import time
+import numpy as np
+
+from quant_trade.signal.ai_inference import compute_ai_scores_batch
+
+
+class DummyPredictor:
+    """简单的预测器, 返回常数分数."""
+
+    def get_ai_score(self, feats, *args, **kwargs):
+        arr = np.asarray(feats)
+        if arr.ndim == 1:
+            arr = arr.reshape(1, -1)
+        return np.full(arr.shape[0], 0.1)
+
+
+def main():
+    n = 1000
+    feats = {"1h": [{"f1": float(i)} for i in range(n)]}
+    models = {"1h": {"up": {}, "down": {}}}
+    calibrators = {"1h": {"up": None, "down": None}}
+    predictor = DummyPredictor()
+
+    start_cpu = time.process_time()
+    t0 = time.perf_counter()
+    compute_ai_scores_batch(predictor, feats, models, calibrators)
+    cpu_time = time.process_time() - start_cpu
+    latency = time.perf_counter() - t0
+    print(f"CPU time: {cpu_time:.4f}s, latency: {latency:.4f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/signal/test_ai_inference_batch.py
+++ b/tests/signal/test_ai_inference_batch.py
@@ -1,0 +1,68 @@
+import threading
+from collections.abc import Mapping
+
+import numpy as np
+
+from quant_trade.ai_model_predictor import AIModelPredictor
+from quant_trade.signal.ai_inference import compute_ai_scores_batch
+from quant_trade.utils.lru import LRU
+
+
+class ConstPipe:
+    def __init__(self, probs, classes=None):
+        self._probs = np.array([probs], dtype=float)
+        self.classes_ = np.array(classes) if classes is not None else np.arange(len(probs))
+
+    def predict_proba(self, df):
+        return np.tile(self._probs, (len(df), 1))
+
+
+def test_ai_model_predictor_batch():
+    model_up = {"pipeline": ConstPipe([0.2, 0.8]), "features": ["a"]}
+    model_down = {"pipeline": ConstPipe([0.8, 0.2]), "features": ["a"]}
+    predictor = AIModelPredictor.__new__(AIModelPredictor)
+    res = predictor.get_ai_score(np.array([[1], [2]]), model_up, model_down)
+    assert isinstance(res, np.ndarray)
+    assert res.shape == (2,)
+    assert np.allclose(res, 0.6)
+
+    model_cls = {"pipeline": ConstPipe([0.2, 0.2, 0.6], classes=[-1, 0, 1]), "features": ["a"]}
+    res_cls = predictor.get_ai_score_cls(np.array([[1], [2]]), model_cls)
+    assert isinstance(res_cls, np.ndarray)
+    assert np.allclose(res_cls, 0.5)
+
+
+def test_compute_ai_scores_batch_thread_safe():
+    class DummyPredictor:
+        def get_ai_score(self, feats, *_, **__):
+            if isinstance(feats, list) and feats and isinstance(feats[0], Mapping):
+                return np.array([f.get("v", 0.0) for f in feats], dtype=float)
+            arr = np.asarray(feats, dtype=float)
+            if arr.ndim == 1:
+                return arr
+            return arr[:, 0]
+
+    predictor = DummyPredictor()
+    feats = {"1h": [{"v": i} for i in range(5)]}
+    models = {"1h": {"up": {}, "down": {}}}
+    calibrators = {"1h": {"up": None, "down": None}}
+    cache = LRU(maxsize=100)
+
+    res = compute_ai_scores_batch(predictor, feats, models, calibrators, cache)
+    assert [r["1h"] for r in res] == [0, 1, 2, 3, 4]
+
+    res_arr = compute_ai_scores_batch(predictor, np.array([[5], [6]]), models, calibrators)
+    assert [r["1h"] for r in res_arr] == [5, 6]
+
+    results = []
+    def worker():
+        results.append(compute_ai_scores_batch(predictor, feats, models, calibrators, cache))
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results[0] == res
+    assert results[1] == res


### PR DESCRIPTION
## Summary
- 支持批量AI分数计算，新增`compute_ai_scores_batch`
- `AIModelPredictor`与信号生成器适配批量推理
- 添加1000根K线基准脚本与并发安全测试

## Testing
- `pytest -q tests` *(fails: AttributeError: 'RobustSignalGenerator' object has no attribute 'ma_cross_logic')*
- `pytest -q tests/signal/test_ai_inference_basic.py tests/signal/test_ai_inference_batch.py`


------
https://chatgpt.com/codex/tasks/task_e_689d49fd398c832ab2b7d1288f9bfe91