### PR TITLE
重构因子权重更新为同步调用

### DIFF
--- a/backtests/calibrate_thresholds.py
+++ b/backtests/calibrate_thresholds.py
@@ -95,7 +95,7 @@ def _evaluate(
             }
         )
 
-    sg.stop_weight_update_thread()
+    sg.update_weights()
     df_rec = pd.DataFrame(records)
     trades = df_rec[df_rec["signal"] != 0]
     if len(trades) < MIN_TRADES or df_rec["pnl"].std(ddof=0) == 0:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,9 +29,7 @@
 |  _factor_cache        |
 +-----+-------------+---+
       |             |
-      |     start_weight_update_thread
-      |             |
-      |     stop_weight_update_thread
+      |     update_weights
       v             v
 +-----+-------------+---+
 |   risk_manager        |
@@ -57,7 +55,7 @@
 - **职责**：融合因子、AI 得分与风险控制，产生交易信号。
 - **不变量**：
   - 缓存命中时返回与重新计算一致的结果；
-  - 权重更新线程始终安全启动与停止，不会泄露资源；
+  - 权重更新通过显式调用 `update_weights` 进行；
   - 信号计算对外接口保持幂等。
 
 ### risk_manager / backtester
@@ -72,7 +70,7 @@
 - **淘汰策略**：超过上限时淘汰最久未使用的数据。
 - **线程安全**：
   - 缓存读写在内部锁保护下执行，防止并发污染；
-  - `start_weight_update_thread` 启动后台线程定期更新因子权重，`stop_weight_update_thread` 确保线程安全退出；
+  - 因子权重由调度器定期调用 `update_weights` 刷新；
   - 多线程环境下，所有共享状态必须通过原子操作或锁维护一致性。
 
 ## 无行为变更

--- a/quant_trade/backtester.py
+++ b/quant_trade/backtester.py
@@ -388,8 +388,8 @@ def run_backtest(
     else:
         all_trades = pd.DataFrame()
     all_trades.to_csv(BASE_DIR / 'backtest_fusion_trades_all.csv', index=False)
-    if hasattr(sg, "stop_weight_update_thread"):
-        sg.stop_weight_update_thread()
+    if hasattr(sg, "update_weights"):
+        sg.update_weights()
 
 if __name__ == '__main__':
     import argparse

--- a/quant_trade/generate_signal_from_db.py
+++ b/quant_trade/generate_signal_from_db.py
@@ -77,8 +77,8 @@ def main(symbol: str = "ETHUSDT") -> None:
 
     logger.info("最新交易信号:\n%s", latest_signal)
     logger.info("%s", pd.DataFrame(results).to_string(index=False))
-    if hasattr(sg, "stop_weight_update_thread"):
-        sg.stop_weight_update_thread()
+    if hasattr(sg, "update_weights"):
+        sg.update_weights()
 
 
 if __name__ == "__main__":

--- a/quant_trade/param_search.py
+++ b/quant_trade/param_search.py
@@ -413,8 +413,8 @@ def run_param_search(
                     ic,
                     sg_iter,
                 )
-                if hasattr(sg_iter, "stop_weight_update_thread"):
-                    sg_iter.stop_weight_update_thread()
+                if hasattr(sg_iter, "update_weights"):
+                    sg_iter.update_weights()
                 ret_vals.append(tot_ret)
                 sharpe_vals.append(sharpe)
                 trades += trade_count
@@ -453,8 +453,8 @@ def run_param_search(
             )
 
         logger.info("best params: %s best_sharpe: %.6f", best, best_metric)
-        if hasattr(sg, "stop_weight_update_thread"):
-            sg.stop_weight_update_thread()
+        if hasattr(sg, "update_weights"):
+            sg.update_weights()
         return best_metric
     else:
         def objective(trial: optuna.Trial) -> float:
@@ -532,8 +532,8 @@ def run_param_search(
                     ic,
                     sg_iter,
                 )
-                if hasattr(sg_iter, "stop_weight_update_thread"):
-                    sg_iter.stop_weight_update_thread()
+                if hasattr(sg_iter, "update_weights"):
+                    sg_iter.update_weights()
                 ret_vals.append(tot_ret)
                 sharpe_vals.append(sharpe)
                 trades += trade_count
@@ -589,8 +589,8 @@ def run_param_search(
         logger.info(
             "best params: %s best_sharpe: %.6f", study.best_params, study.best_value
         )
-        if hasattr(sg, "stop_weight_update_thread"):
-            sg.stop_weight_update_thread()
+        if hasattr(sg, "update_weights"):
+            sg.update_weights()
         return study.best_value
 
 

--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -263,10 +263,10 @@ class Scheduler:
             )
             self.cfg = load_config()
             rsg_cfg = RobustSignalGeneratorConfig.from_cfg(self.cfg)
-            self.sg.stop_weight_update_thread()
             self.sg = RobustSignalGenerator(rsg_cfg)
             categories = load_symbol_categories(self.engine)
             self.sg.set_symbol_categories(categories)
+            self.sg.update_weights()
         except (OSError, ValueError, RuntimeError) as exc:
             logger.exception("search_and_reload_params failed")
 
@@ -538,7 +538,7 @@ class Scheduler:
         except KeyboardInterrupt:
             logging.info("scheduler stopped")
         finally:
-            self.sg.stop_weight_update_thread()
+            self.sg.update_weights()
 
 
 if __name__ == "__main__":

--- a/tests/signal/test_golden_batch.py
+++ b/tests/signal/test_golden_batch.py
@@ -73,4 +73,4 @@ def test_golden_batch(cases_data, monkeypatch):
         for field in ("vote", "protect", "env", "exit", "factors"):
             assert field in details
 
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()

--- a/tests/signal/test_golden_single.py
+++ b/tests/signal/test_golden_single.py
@@ -66,7 +66,7 @@ def test_golden_single(case_data, monkeypatch):
 
     assert isinstance(result["details"], dict)
 
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 
 
 def test_generate_signal_structure_consistency(case_data, monkeypatch):
@@ -128,4 +128,4 @@ def test_generate_signal_structure_consistency(case_data, monkeypatch):
         assert expected_keys.issubset(result.keys())
         assert isinstance(result["details"], dict)
 
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()

--- a/tests/test_delta_boost.py
+++ b/tests/test_delta_boost.py
@@ -24,4 +24,4 @@ def test_delta_boost():
     s0 = 0.5
     s1 = g._apply_delta_boost(s0, d)
     assert s1 > s0
-    g.stop_weight_update_thread()
+    g.update_weights()

--- a/tests/test_get_ai_score.py
+++ b/tests/test_get_ai_score.py
@@ -32,4 +32,4 @@ def test_get_ai_score_auto_features(tmp_path):
     df = pd.DataFrame({"f1": [0.5], "f2": [0.1]})
     score = rsg.predictor.get_ai_score(df, rsg.models["1h"]["up"], rsg.models["1h"]["down"])
     assert score == pytest.approx(1.0)
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()

--- a/tests/test_phase_config.py
+++ b/tests/test_phase_config.py
@@ -24,7 +24,7 @@ def test_update_market_phase_uses_config(tmp_path, monkeypatch):
     )
     rsg.update_market_phase(None)
     assert rsg.phase_th_mult == pytest.approx(0.8)
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 
 
 def test_update_phase_dir_mult(tmp_path, monkeypatch):
@@ -52,4 +52,4 @@ def test_update_phase_dir_mult(tmp_path, monkeypatch):
     )
     rsg.update_market_phase(None)
     assert rsg.phase_dir_mult == {"long": 1, "short": 2}
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()

--- a/tests/test_phase_dir_mult.py
+++ b/tests/test_phase_dir_mult.py
@@ -101,7 +101,7 @@ def test_bull_phase_dir_multiplier(tmp_path, monkeypatch):
     res = rsg.generate_signal({}, {}, {})
     assert cap["score"] == pytest.approx(1.0)
     assert res["signal"] == 1
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 
 
 def test_bear_phase_dir_multiplier(tmp_path, monkeypatch):
@@ -116,5 +116,5 @@ def test_bear_phase_dir_multiplier(tmp_path, monkeypatch):
     res = rsg.generate_signal({}, {}, {})
     assert cap["score"] == pytest.approx(-1.0)
     assert res["signal"] == -1
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 

--- a/tests/test_rsg_load_path.py
+++ b/tests/test_rsg_load_path.py
@@ -17,7 +17,7 @@ def test_model_path_resolution(tmp_path, monkeypatch):
     rsg = RobustSignalGenerator(cfg)
     assert "cls" in rsg.models.get("1h", {})
     assert hasattr(rsg.models["1h"]["cls"]["pipeline"], "predict")
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 
 
 def test_base_weights_from_config(tmp_path, monkeypatch):
@@ -56,7 +56,7 @@ ic_scores:
         "funding": 3 / total,
     }
     assert rsg.base_weights == pytest.approx(expected)
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 
 
 def test_signal_threshold_from_config(tmp_path, monkeypatch):
@@ -78,5 +78,5 @@ signal_threshold:
     )
     rsg = RobustSignalGenerator(cfg)
     assert rsg.signal_threshold_cfg["base_th"] == pytest.approx(0.2)
-    rsg.stop_weight_update_thread()
+    rsg.update_weights()
 

--- a/tests/test_signal_generator.py
+++ b/tests/test_signal_generator.py
@@ -3,7 +3,11 @@ import pytest
 
 from quant_trade.tests.test_utils import make_dummy_rsg
 from quant_trade.data_loader import compute_vix_proxy
-from quant_trade.robust_signal_generator import SignalThresholdParams, DynamicThresholdInput
+from quant_trade.robust_signal_generator import (
+    SignalThresholdParams,
+    DynamicThresholdInput,
+    RobustSignalGenerator,
+)
 from quant_trade.signal import compute_dynamic_threshold
 
 
@@ -371,6 +375,7 @@ def test_update_ic_scores_window_group(monkeypatch):
 
 def test_dynamic_weight_update(monkeypatch):
     rsg = make_dummy_rsg()
+    rsg.dynamic_weight_update = RobustSignalGenerator.dynamic_weight_update.__get__(rsg)
 
     import pandas as pd
     df = pd.DataFrame({"open_time": [0], "open": [1], "close": [1]})
@@ -384,7 +389,7 @@ def test_dynamic_weight_update(monkeypatch):
     ))
 
     rsg.update_ic_scores(df)
-    weights = rsg.dynamic_weight_update()
+    weights = rsg.update_weights()
 
     base_arr = np.array(list(rsg.base_weights.values()))
     ic_arr = np.array(list(rsg.ic_scores.values()))


### PR DESCRIPTION
## 摘要
- 提供 `update_weights` 同步方法，整合原动态权重计算
- 调度器改为显式调用 `update_weights`，移除线程式清理
- 更新多处测试与脚本，替换旧线程接口

## 测试
- `pytest tests/test_signal_generator.py::test_dynamic_weight_update tests/test_rsg.py::test_dynamic_weight_non_negative_sum_one tests/test_rsg.py::test_dynamic_weight_recent_ic_priority tests/test_rsg.py::test_dynamic_weight_handles_nan_history tests/test_rsg.py::test_update_dynamic_weights_sets_w_ai -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4ec75f80832a8b11c692b55554c1