### PR TITLE
ci: run subset of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: ruff .
       - run: mypy .
       - run: pytest -q
+      - run: pytest -q tests/test_dynamic_thresholds.py tests/test_risk_filters.py tests/test_position_sizing.py


### PR DESCRIPTION
## Summary
- 在 CI 工作流中，在原有 pytest 步骤之后新增一项仅执行动态阈值、风险过滤与仓位管理相关测试。

## Testing
- `pytest -q tests` *(fails: assert failures and AttributeError)*
- `pytest -q tests/test_dynamic_thresholds.py tests/test_risk_filters.py tests/test_position_sizing.py`

------
https://chatgpt.com/codex/tasks/task_e_689d6d3ac6f4832a85f2989322a4ae8c