### PR TITLE
feat: add safe merge utility

### DIFF
--- a/quant_trade/feature_engineering.py
+++ b/quant_trade/feature_engineering.py
@@ -27,6 +27,7 @@ from quant_trade.utils.helper import (
     calc_features_raw,
     calc_order_book_features,
 )  # pylint: disable=import-error
+from quant_trade.features import safe_merge
 
 # Robust-z 参数持久化工具
 from quant_trade.utils.robust_scaler import (
@@ -859,10 +860,14 @@ class FeatureEngineer:
                 on="open_time",
                 direction="backward",
             )
-
+        merged.set_index("open_time", inplace=True)
+        merged = merged.select_dtypes(include="number")
+        shifted = safe_merge(df_1h[["open", "high", "low", "close", "volume"]], merged)
+        shifted = shifted.drop(columns=["open", "high", "low", "close", "volume"])
+        shifted.reset_index(inplace=True)
         raw = df_1h.reset_index()
         out = raw.merge(
-            merged,
+            shifted,
             on="open_time",
             how="left",
             suffixes=("", "_feat"),

--- a/quant_trade/features/__init__.py
+++ b/quant_trade/features/__init__.py
@@ -1,0 +1,5 @@
+"""Feature utilities."""
+
+from .feature_engineer import safe_merge
+
+__all__ = ["safe_merge"]

--- a/quant_trade/features/feature_engineer.py
+++ b/quant_trade/features/feature_engineer.py
@@ -1,0 +1,48 @@
+"""Utilities for merging feature blocks safely."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def safe_merge(
+    base_k: pd.DataFrame,
+    *ext_blocks: pd.DataFrame | None,
+    core_cols: tuple[str, ...] = ("open", "high", "low", "close", "volume"),
+) -> pd.DataFrame:
+    """Safely align and merge external feature blocks onto a base kline.
+
+    Parameters
+    ----------
+    base_k
+        Base kline DataFrame indexed by ``open_time``.
+    *ext_blocks
+        Additional feature blocks to merge. ``None`` or empty DataFrames are
+        ignored. Each block is reindexed to ``base_k``'s index, shifted by one
+        step to avoid lookahead bias and cast to ``float64`` before merging.
+    core_cols
+        Core OHLCV columns used to identify valid rows.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Concatenated DataFrame with aligned features where rows with all core
+        columns missing are removed.
+    """
+
+    if not isinstance(base_k, pd.DataFrame):
+        raise TypeError("base_k must be a pandas DataFrame")
+
+    base = base_k.dropna(how="all", subset=list(core_cols))
+    blocks: list[pd.DataFrame] = [base]
+
+    for blk in ext_blocks:
+        if blk is None:
+            continue
+        if hasattr(blk, "empty") and blk.empty:
+            continue
+        aligned = blk.reindex(base.index).shift(1).astype("float64")
+        blocks.append(aligned)
+
+    merged = pd.concat(blocks, axis=1)
+    return merged.dropna(subset=list(core_cols))

--- a/tests/test_order_book_features.py
+++ b/tests/test_order_book_features.py
@@ -120,7 +120,10 @@ def test_merge_features_with_order_book(tmp_path):
     fe.merge_features(save_to_db=False, batch_size=None)
     out_df = fe.out_df
     assert 'bid_ask_imbalance' in out_df.columns
-    assert out_df['bid_ask_imbalance'].iloc[0] == pytest.approx((20-10)/30)
+    imb = out_df['bid_ask_imbalance']
+    assert pd.isna(imb.iloc[0])
+    first_valid = imb.dropna().iloc[0]
+    assert first_valid == pytest.approx((20-10)/30)
 
 
 def test_merge_features_scaler_batch(tmp_path):

--- a/tests/test_safe_merge.py
+++ b/tests/test_safe_merge.py
@@ -1,0 +1,34 @@
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from quant_trade.features import safe_merge
+
+
+def test_safe_merge_basic():
+    idx = pd.RangeIndex(3)
+    base = pd.DataFrame(
+        {
+            "open": [1.0, 2.0, np.nan],
+            "high": [1.0, 2.0, np.nan],
+            "low": [1.0, 2.0, np.nan],
+            "close": [1.0, 2.0, np.nan],
+            "volume": [1.0, 2.0, np.nan],
+        },
+        index=idx,
+    )
+    ext = pd.DataFrame({"feat": [10, 20, 30]}, index=idx)
+
+    merged = safe_merge(base, ext)
+
+    assert len(merged) == 2
+    assert pd.isna(merged["feat"].iloc[0])
+    assert merged["feat"].iloc[1] == 10
+
+    naive = pd.concat([base, ext], axis=1)
+    assert merged.isna().mean().mean() < naive.isna().mean().mean()
+
+    with warnings.catch_warnings(record=True) as w:
+        merged.isna().mean()
+        assert not any("All-NaN" in str(warn.message) for warn in w)


### PR DESCRIPTION
## Summary
- add `safe_merge` to align and lag external feature blocks
- integrate `safe_merge` into feature engineering flow
- test merge behavior and lagging of order book features

## Testing
- `pytest tests/test_safe_merge.py tests/test_order_book_features.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_689d93c25364832a975350ce6d2f3466