### PR TITLE
feat: allow unfilled limit orders

### DIFF
--- a/quant_trade/backtest/__init__.py
+++ b/quant_trade/backtest/__init__.py
@@ -1,0 +1,1 @@
+"""Backtesting utilities."""

--- a/quant_trade/backtest/backtester.py
+++ b/quant_trade/backtest/backtester.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Simple backtesting helpers."""
+
+from typing import Optional, Tuple
+
+
+def execute_signal(
+    price_open_next: float,
+    price_high_next: float,
+    price_low_next: float,
+    direction: int,
+    *,
+    slippage: float = 0.0,
+) -> Tuple[Optional[float], float]:
+    """Attempt to execute a pending order.
+
+    Parameters
+    ----------
+    price_open_next : float
+        The opening price of the next bar.
+    price_high_next : float
+        The high price of the next bar.
+    price_low_next : float
+        The low price of the next bar.
+    direction : int
+        Trade direction, ``1`` for buy and ``-1`` for sell.
+    slippage : float, optional
+        Fraction used to offset the opening price when placing the order.
+
+    Returns
+    -------
+    tuple
+        ``(fill_price, pnl)`` where ``fill_price`` is ``None`` if the order
+        is not filled and ``pnl`` is ``0.0`` in that case.
+    """
+    if direction not in (1, -1):
+        return None, 0.0
+
+    # Determine the limit order price using an offset from the next open price.
+    limit_price = (
+        price_open_next * (1 - slippage)
+        if direction == 1
+        else price_open_next * (1 + slippage)
+    )
+
+    # Use strict inequalities so the order may remain unfilled.
+    if direction == 1:
+        if price_low_next < limit_price:
+            return limit_price, 0.0
+    else:
+        if price_high_next > limit_price:
+            return limit_price, 0.0
+
+    return None, 0.0

--- a/tests/test_execute_signal.py
+++ b/tests/test_execute_signal.py
@@ -1,0 +1,17 @@
+from quant_trade.backtest.backtester import execute_signal
+
+
+def test_execute_signal_unfilled_buy():
+    # Order placed slightly below the next open price
+    price_open_next = 100.0
+    price_high_next = 101.0
+    price_low_next = 99.6  # price never drops enough to fill
+    fill, pnl = execute_signal(
+        price_open_next,
+        price_high_next,
+        price_low_next,
+        1,
+        slippage=0.01,
+    )
+    assert fill is None
+    assert pnl == 0.0


### PR DESCRIPTION
## Summary
- add simple backtesting helper with limit order execution that may remain unfilled
- test execute_signal returns `(None, 0.0)` when price never touches order

## Testing
- `pytest -q tests/test_execute_signal.py`
- `pytest -q tests` *(fails: KeyError and assertion errors in unrelated signal generator tests)*

------
https://chatgpt.com/codex/tasks/task_e_689dc2f23244832a986d19c7be809d64