### PR TITLE
feat: add slippage model and tests

### DIFF
--- a/quant_trade/slippage_model.py
+++ b/quant_trade/slippage_model.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SlippageModel:
+    """Simple model for estimating slippage in basis points.
+
+    Parameters
+    ----------
+    hv_cap : float, optional
+        Maximum allowed annualized volatility. Values of ``hv`` passed to
+        :meth:`slippage_bp` will be clipped to the range ``[0, hv_cap]``.
+    bp_per_hv : float, optional
+        Number of basis points corresponding to ``hv=1.0``.
+    """
+
+    hv_cap: float = 1.0
+    bp_per_hv: float = 10000.0
+
+    def slippage_bp(self, hv: float) -> float:
+        """Return slippage in basis points for a given volatility.
+
+        Parameters
+        ----------
+        hv : float
+            Annualized volatility (0~1).
+
+        Returns
+        -------
+        float
+            Slippage cost expressed in basis points.
+        """
+        hv = min(max(hv, 0.0), self.hv_cap)
+        return hv * self.bp_per_hv

--- a/tests/test_slippage_model.py
+++ b/tests/test_slippage_model.py
@@ -1,0 +1,13 @@
+import pytest
+
+from quant_trade.slippage_model import SlippageModel
+
+
+def test_slippage_bp_negative_hv():
+    model = SlippageModel()
+    assert model.slippage_bp(-0.5) == 0.0
+
+
+def test_slippage_bp_extreme_hv():
+    model = SlippageModel(hv_cap=0.3)
+    assert model.slippage_bp(10.0) == pytest.approx(0.3 * model.bp_per_hv)


### PR DESCRIPTION
## Summary
- add SlippageModel for volatility-based slippage estimation
- clamp annualized volatility input and document hv range
- test slippage calculation with negative and extreme volatility values

## Testing
- `pytest -q tests/test_slippage_model.py`
- `pytest -q tests` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'ThresholdParams')*

------
https://chatgpt.com/codex/tasks/task_e_689dc7161658832a8e66fb2ae2c6b82d