### PR TITLE
feat: 支持多分类指标

### DIFF
--- a/tests/test_classification_metrics_report.py
+++ b/tests/test_classification_metrics_report.py
@@ -4,7 +4,7 @@ import importlib
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.metrics import roc_auc_score, brier_score_loss, log_loss
+from sklearn.metrics import roc_auc_score, log_loss
 from sklearn.calibration import calibration_curve
 
 
@@ -14,20 +14,25 @@ def test_compute_metrics_and_report(tmp_path, monkeypatch):
     sys.modules.pop('quant_trade.model_trainer', None)
     mt = importlib.import_module('quant_trade.model_trainer')
 
-    y_true = np.array([0, 1, 1, 0])
+    y_true = np.array([0, 1, 2, 1])
     proba = np.array([
-        [0.9, 0.1],
-        [0.2, 0.8],
-        [0.3, 0.7],
-        [0.6, 0.4],
+        [0.7, 0.2, 0.1],
+        [0.1, 0.6, 0.3],
+        [0.2, 0.2, 0.6],
+        [0.3, 0.4, 0.3],
     ])
     metrics, calib = mt.compute_classification_metrics(y_true, proba)
     assert metrics['LogLoss'] == pytest.approx(log_loss(y_true, proba))
-    assert metrics['AUC'] == pytest.approx(roc_auc_score(y_true, proba[:, 1]))
-    assert metrics['Brier'] == pytest.approx(brier_score_loss(y_true, proba[:, 1]))
-    pt, pp = calibration_curve(y_true, proba[:, 1], n_bins=10)
-    assert calib['prob_true'] == pt.tolist()
-    assert calib['prob_pred'] == pp.tolist()
+    assert metrics['AUC'] == pytest.approx(
+        roc_auc_score(y_true, proba, multi_class='ovr', average='macro')
+    )
+    y_onehot = np.eye(proba.shape[1])[y_true]
+    expected_brier = np.mean(np.sum((proba - y_onehot) ** 2, axis=1))
+    assert metrics['Brier'] == pytest.approx(expected_brier)
+    for i in range(proba.shape[1]):
+        pt, pp = calibration_curve((y_true == i).astype(int), proba[:, i], n_bins=10)
+        assert calib[str(i)]['prob_true'] == pt.tolist()
+        assert calib[str(i)]['prob_pred'] == pp.tolist()
 
     report = {
         'splits': {**mt.cv_cfg, 'n_splits': 5},
@@ -42,6 +47,6 @@ def test_compute_metrics_and_report(tmp_path, monkeypatch):
         loaded = json.load(f)
     assert 'AUC' in loaded['metrics']
     assert 'Brier' in loaded['metrics']
-    assert len(loaded['calibration_curve']['prob_true']) == len(
-        loaded['calibration_curve']['prob_pred']
-    )
+    assert len(loaded['calibration_curve']) == proba.shape[1]
+    for v in loaded['calibration_curve'].values():
+        assert len(v['prob_true']) == len(v['prob_pred'])


### PR DESCRIPTION
## Summary
- 更新 `compute_classification_metrics` 以支持多分类的 AUC、Brier 分数与逐类校准曲线
- 调整测试覆盖三分类概率矩阵

## Testing
- `pytest tests/test_classification_metrics_report.py -q`
- `pytest -q tests` *(fails: AttributeError 等多项错误)*

------
https://chatgpt.com/codex/tasks/task_e_689e391acfa4832ab27e68a39146d4fc