### PR TITLE
Add decision signal configuration helper

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -4,6 +4,7 @@ from .core import generate_signal
 from .features_to_scores import get_factor_scores, get_factor_scores_batch
 from .ai_inference import get_period_ai_scores, get_reg_predictions
 from .multi_period_fusion import fuse_scores
+from .decision import DecisionConfig, decide_signal
 from .dynamic_thresholds import (
     DynamicThresholdInput,
     SignalThresholdParams,
@@ -34,6 +35,8 @@ __all__ = [
     "get_period_ai_scores",
     "get_reg_predictions",
     "fuse_scores",
+    "DecisionConfig",
+    "decide_signal",
     "DynamicThresholdInput",
     "SignalThresholdParams",
     "DynamicThresholdParams",

--- a/quant_trade/signal/decision.py
+++ b/quant_trade/signal/decision.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""简单的信号决策模块。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class DecisionConfig:
+    """决策配置。
+
+    Attributes
+    ----------
+    upper : float
+        触发买入信号的上阈值。
+    lower : float
+        触发卖出信号的下阈值。
+    buy : float
+        表示买入的信号数值。
+    sell : float
+        表示卖出的信号数值。
+    hold : float
+        表示保持仓位的信号数值。
+    """
+
+    upper: float = 0.5
+    lower: float = -0.5
+    buy: float = 1.0
+    sell: float = -1.0
+    hold: float = 0.0
+
+
+def decide_signal(scores: np.ndarray, config: DecisionConfig) -> np.ndarray:
+    """根据得分生成交易信号。
+
+    Parameters
+    ----------
+    scores : np.ndarray
+        模型得分或指标值。
+    config : DecisionConfig
+        决策配置参数。
+
+    Returns
+    -------
+    np.ndarray
+        与 ``scores`` 形状一致的信号数组，取值为 ``config.buy``、
+        ``config.sell`` 或 ``config.hold``。
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    signals = np.full(scores.shape, config.hold, dtype=float)
+    signals[scores >= config.upper] = config.buy
+    signals[scores <= config.lower] = config.sell
+    return signals


### PR DESCRIPTION
## Summary
- add `DecisionConfig` dataclass and `decide_signal` helper
- re-export decision helpers in `quant_trade.signal`

## Testing
- `python -m pytest -q tests` *(fails: multiple missing attributes and KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_689ec04bd8e0832a91403d3fc567f211