### PR TITLE
feat: unify decision logic for backtest and live signals

### DIFF
--- a/quant_trade/signal/decision.py
+++ b/quant_trade/signal/decision.py
@@ -1,56 +1,110 @@
 # -*- coding: utf-8 -*-
-"""简单的信号决策模块。"""
+"""信号决策模块。
+
+该文件提供统一的 ``decide_signal`` 函数, 供回测与实盘模块调
+用以避免两套分歧的逻辑。函数基于分类概率以及若干预测值
+做出买卖/观望的决策, 并返回操作方向、仓位大小以及备注信
+息。
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Mapping, Any
+
 import numpy as np
 
 
 @dataclass
 class DecisionConfig:
-    """决策配置。
+    """决策参数配置。
 
-    Attributes
-    ----------
-    upper : float
-        触发买入信号的上阈值。
-    lower : float
-        触发卖出信号的下阈值。
-    buy : float
-        表示买入的信号数值。
-    sell : float
-        表示卖出的信号数值。
-    hold : float
-        表示保持仓位的信号数值。
+    这里的字段与 ``config.yaml`` 中 ``signal`` 节点的键保持一致,
+    仅保留在回测与测试中会用到的几个关键参数。
     """
 
-    upper: float = 0.5
-    lower: float = -0.5
-    buy: float = 1.0
-    sell: float = -1.0
-    hold: float = 0.0
+    p_up_min: float = 0.6
+    p_down_min: float = 0.6
+    margin_min: float = 0.10
+    pmin_bump_when_conflict: float = 0.03
+    kelly_gamma: float = 0.20
+    w_max: float = 0.5
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DecisionConfig":
+        allowed = {k: data[k] for k in cls.__annotations__.keys() if k in data}
+        return cls(**allowed)
 
 
-def decide_signal(scores: np.ndarray, config: DecisionConfig) -> np.ndarray:
-    """根据得分生成交易信号。
+def _get_probs(probs: Mapping[str, float] | np.ndarray) -> tuple[float, float]:
+    """从数组或映射中提取 ``p_up`` 与 ``p_down``。"""
+
+    if isinstance(probs, Mapping):
+        p_up = float(probs.get("up", probs.get("buy", 0.0)))
+        p_down = float(probs.get("down", probs.get("sell", 0.0)))
+    else:
+        arr = np.asarray(probs, dtype=float).reshape(-1)
+        if arr.size == 2:  # (p_down, p_up)
+            p_down, p_up = float(arr[0]), float(arr[1])
+        elif arr.size >= 3:  # (p_down, p_hold, p_up)
+            p_down, p_up = float(arr[0]), float(arr[-1])
+        else:  # 单个数视为 p_up
+            p_up = float(arr[0])
+            p_down = 1.0 - p_up
+    return p_up, p_down
+
+
+def decide_signal(
+    probs: Mapping[str, float] | np.ndarray,
+    rise_pred: float | None,
+    drawdown_pred: float | None,
+    vol_pred: float | None,
+    higher_conflict: bool,
+    config: DecisionConfig,
+) -> Mapping[str, Any]:
+    """根据概率和预测信息生成交易信号。
 
     Parameters
     ----------
-    scores : np.ndarray
-        模型得分或指标值。
-    config : DecisionConfig
-        决策配置参数。
+    probs:
+        分类概率, 支持 ``{"up": p, "down": q}`` 或 ``[p_down, p_hold, p_up]``
+        等形式。
+    rise_pred, drawdown_pred, vol_pred:
+        模型对未来涨幅、回撤以及波动率的预测, 当前实现仅用于
+        占位, 以便后续扩展。
+    higher_conflict:
+        上级周期是否与当前周期冲突的标志位。
+    config:
+        决策配置。
 
     Returns
     -------
-    np.ndarray
-        与 ``scores`` 形状一致的信号数组，取值为 ``config.buy``、
-        ``config.sell`` 或 ``config.hold``。
+    dict
+        包含 ``action`` (BUY/SELL/HOLD)、``size`` 以及 ``note`` 的字典。
     """
 
-    scores = np.asarray(scores, dtype=float)
-    signals = np.full(scores.shape, config.hold, dtype=float)
-    signals[scores >= config.upper] = config.buy
-    signals[scores <= config.lower] = config.sell
-    return signals
+    p_up, p_down = _get_probs(probs)
+    margin = p_up - p_down
+
+    bump = config.pmin_bump_when_conflict if higher_conflict else 0.0
+    p_up_th = config.p_up_min + bump
+    p_down_th = config.p_down_min + bump
+
+    action = "HOLD"
+    size = 0.0
+    note = "hold"
+
+    if p_up >= p_up_th and margin >= config.margin_min:
+        action = "BUY"
+        size = min(config.w_max, config.kelly_gamma * (p_up - p_up_th))
+        note = f"p_up={p_up:.2f}"
+    elif p_down >= p_down_th and -margin >= config.margin_min:
+        action = "SELL"
+        size = min(config.w_max, config.kelly_gamma * (p_down - p_down_th))
+        note = f"p_down={p_down:.2f}"
+
+    return {"action": action, "size": size, "note": note}
+
+
+__all__ = ["DecisionConfig", "decide_signal"]
+

--- a/tests/test_decision_module.py
+++ b/tests/test_decision_module.py
@@ -1,0 +1,25 @@
+import numpy as np
+import yaml
+from pathlib import Path
+
+from quant_trade.signal.decision import DecisionConfig, decide_signal
+
+
+def test_decide_signal_basic():
+    cfg = DecisionConfig(p_up_min=0.6, p_down_min=0.6, margin_min=0.1, kelly_gamma=0.5, w_max=1.0)
+    res_buy = decide_signal(np.array([0.1, 0.2, 0.7]), None, None, None, False, cfg)
+    assert res_buy["action"] == "BUY"
+    assert res_buy["size"] > 0
+
+    res_sell = decide_signal(np.array([0.7, 0.2, 0.1]), None, None, None, False, cfg)
+    assert res_sell["action"] == "SELL"
+
+    res_hold = decide_signal(np.array([0.4, 0.2, 0.4]), None, None, None, False, cfg)
+    assert res_hold["action"] == "HOLD"
+
+
+def test_decision_config_from_yaml():
+    path = Path("quant_trade/utils/config.yaml")
+    cfg = yaml.safe_load(path.read_text())
+    dcfg = DecisionConfig.from_dict(cfg.get("signal", {}))
+    assert isinstance(dcfg, DecisionConfig)


### PR DESCRIPTION
## Summary
- add flexible DecisionConfig and decide_signal for unified BUY/SELL/HOLD decisions
- integrate decision flow into backtester and DB-driven signal generator
- cover decision module with new tests

## Testing
- `pytest -q tests/test_decision_module.py -q`
- `pytest -q tests/test_backtester_single.py::test_run_single_backtest_basic -q` *(fails: assert 0.028070791138896004 == 0.0280853 ± 2.8e-06)*

------
https://chatgpt.com/codex/tasks/task_e_689ec8b40c78832a886dc6ac5983cbb4