### PR TITLE
扩展 CoinGecko 更新异常处理

### DIFF
--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -196,7 +196,12 @@ class Scheduler:
             self.dl.update_cg_market_data(symbols)
             self.dl.update_cg_coin_categories(symbols)
             self.dl.update_cg_category_stats()
-        except (requests.exceptions.RequestException, ValueError, OSError) as exc:
+        except (
+            requests.exceptions.RequestException,
+            ValueError,
+            OSError,
+            RuntimeError,
+        ) as exc:
             logger.exception("update coingecko failed")
         try:
             self.dl.update_cm_metrics(symbols)


### PR DESCRIPTION
## Summary
- broaden exception handling for CoinGecko data updates in scheduler to include RuntimeError, preventing crashes

## Testing
- `pytest -q tests` *(fails: TypeError and others)*

------
https://chatgpt.com/codex/tasks/task_e_689ef5384b34832a9286b53b6da9074f