### PR TITLE
在初始同步中安全更新市场阶段

### DIFF
--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -149,7 +149,7 @@ class Scheduler:
         self.safe_call(self.update_funding_rates, self.symbols)
         self.safe_call(self.update_daily_data, self.symbols)
         # 根据最新链上指标更新市场阶段参数
-        self.sg.update_market_phase(self.engine)
+        self.safe_call(self.sg.update_market_phase, self.engine)
         self.safe_call(self.update_ic_scores_from_db)
         self.safe_call(self.generate_signals, self.symbols)
         self.next_ic_update = self._calc_next_ic_update(datetime.now(UTC))


### PR DESCRIPTION
## Summary
- 使用 `safe_call` 包裹 `update_market_phase`，避免市场阶段更新失败影响后续同步

## Testing
- `pytest -q tests` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'ThresholdParams')*

------
https://chatgpt.com/codex/tasks/task_e_689efdaca634832aa99311898b5a452a