### PR TITLE
feat: 配置信号生成器基准权重

### DIFF
--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -114,8 +114,10 @@ class Scheduler:
         )
         rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
         self.sg = RobustSignalGenerator(rsg_cfg)
+        self.sg.base_weights = self.cfg.get("ic_scores", {}).get("base_weights", {})
         categories = load_symbol_categories(self.engine)
         self.sg.set_symbol_categories(categories)
+        self.sg.update_weights()
         # 调度器与线程池，用于更精确和并发地执行任务
         import sched
         from concurrent.futures import ThreadPoolExecutor
@@ -269,6 +271,7 @@ class Scheduler:
             self.cfg = load_config()
             rsg_cfg = RobustSignalGeneratorConfig.from_cfg(self.cfg)
             self.sg = RobustSignalGenerator(rsg_cfg)
+            self.sg.base_weights = self.cfg.get("ic_scores", {}).get("base_weights", {})
             categories = load_symbol_categories(self.engine)
             self.sg.set_symbol_categories(categories)
             self.sg.update_weights()


### PR DESCRIPTION
## Summary
- 初始化调度器时为 RobustSignalGenerator 设置 base_weights 并刷新权重
- 重新加载参数时同步应用 base_weights 并更新权重

## Testing
- `python3 -m pytest -q tests` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689f0be6f284832a802309192f84b3f6