### PR TITLE
在 compute_ic_scores 中添加 base_weights 校验

### DIFF
--- a/quant_trade/param_search.py
+++ b/quant_trade/param_search.py
@@ -30,6 +30,8 @@ logger = get_logger(__name__)
 
 def compute_ic_scores(df: pd.DataFrame, rsg: RobustSignalGenerator) -> dict:
     """根据历史数据计算各因子的 IC 分数"""
+    if not hasattr(rsg, "base_weights"):
+        raise ValueError("RobustSignalGenerator 必须先设置 base_weights 才能计算 IC 分数")
     df = df.sort_values("open_time").reset_index(drop=True)
     returns = df["close"].shift(-1) / df["open"].shift(-1) - 1
     scores = {k: [] for k in rsg.base_weights}


### PR DESCRIPTION
## Summary
- 检查 RobustSignalGenerator 是否已设置 base_weights，未设置时抛出明确错误

## Testing
- `pytest -q tests/test_param_search.py`
- `pytest -q tests` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'ThresholdParams', among others)*

------
https://chatgpt.com/codex/tasks/task_e_689f1707e920832aa2b1ee0b14af1ee2