### PR TITLE
feat: integrate AI predictor into scheduler

### DIFF
--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -103,6 +103,8 @@ class Scheduler:
     def __init__(self) -> None:
         from quant_trade.data_loader import DataLoader
         from quant_trade.feature_engineering import FeatureEngineer
+        from quant_trade.ai_model_predictor import AIModelPredictor
+        from quant_trade.signal import PredictorAdapter, FactorScorerImpl
 
         cfg = load_config()
         self.cfg = cfg
@@ -114,6 +116,11 @@ class Scheduler:
         )
         rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
         self.sg = RobustSignalGenerator(rsg_cfg)
+        model_paths = cfg.get("model_paths", {})
+        ai_predictor = AIModelPredictor(model_paths)
+        self.sg.predictor = PredictorAdapter(ai_predictor)
+        self.sg.models = self.sg.predictor.ai_predictor.models
+        self.sg.factor_scorer = FactorScorerImpl(self.sg)
         self.sg.base_weights = self.cfg.get("ic_scores", {}).get("base_weights", {})
         categories = load_symbol_categories(self.engine)
         self.sg.set_symbol_categories(categories)


### PR DESCRIPTION
## Summary
- load AI models in `Scheduler.__init__`
- wire up `PredictorAdapter` and `FactorScorerImpl`

## Testing
- `pytest -q tests` *(fails: assert 0.010956281570688927 <= 0.01)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e09af44832a8cd4f0b341e0cbc8