### PR TITLE
feat: validate rsg deps before IC calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ features → AI → 因子 → (融合) → 阈值 → (风控倍率) → 两阶
 `mysql < scripts/migrate_add_feature_columns.sql`。
 
 通过 `python -m quant_trade.param_search --rows 10000` (可选) 调整信号权重。
+`param_search.compute_ic_scores` 需在 `RobustSignalGenerator` 已配置 `models`、`predictor`
+和 `factor_scorer` 的前提下运行，否则会返回空结果并记录警告。
 参数搜索默认按时间拆分为训练集和验证集，可通过 `--test-ratio` 调整验证集比例。
 脚本默认使用 Optuna 搜索，并同时优化 Δ-boost 参数，例如：
 

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -22,6 +22,11 @@ def make_dummy_rsg():
     rsg.factor_scorer = FactorScorerImpl(rsg)
     rsg.history_scores = deque(maxlen=500)
     rsg.oi_change_history = deque(maxlen=500)
+    rsg.models = {
+        "1h": {"up": None, "down": None},
+        "4h": {"up": None, "down": None},
+        "d1": {"up": None, "down": None},
+    }
 
     rsg.symbol_categories = {}
 

--- a/tests/test_param_search.py
+++ b/tests/test_param_search.py
@@ -7,6 +7,18 @@ from quant_trade import param_search
 import quant_trade.utils.db as db
 
 
+def test_compute_ic_scores_missing_components(caplog):
+    class DummyRSG:
+        def __init__(self):
+            self.base_weights = {"ai": 1}
+
+    df = pd.DataFrame({"open_time": [0], "open": [1], "close": [1]})
+    with caplog.at_level("WARNING"):
+        result = param_search.compute_ic_scores(df, DummyRSG())
+    assert result == {}
+    assert "缺少依赖" in caplog.text
+
+
 def dummy_study(*args, **kwargs):
     class DummyTrial:
         def suggest_float(self, name, low, high):


### PR DESCRIPTION
## Summary
- warn and return empty IC scores when RobustSignalGenerator lacks required components
- document compute_ic_scores prerequisites in README
- cover missing-component case with new tests

## Testing
- `pytest -q tests/test_param_search.py`
- `pytest -q tests` *(fails: assert 0.0 == 0.004596181211551101 ± 4.6e-09, ...)*

------
https://chatgpt.com/codex/tasks/task_e_689f30f07a9c832a91ade838d6047526