### PR TITLE
按需加载模型以计算 IC 分数

### DIFF
--- a/quant_trade/param_search.py
+++ b/quant_trade/param_search.py
@@ -22,6 +22,8 @@ from quant_trade.backtester import (
     MODEL_PATHS,
     simulate_trades,
 )
+from quant_trade.ai_model_predictor import AIModelPredictor
+from quant_trade.signal import PredictorAdapter
 from quant_trade.utils.db import load_config, connect_mysql
 from quant_trade.logging import get_logger
 
@@ -92,6 +94,10 @@ def compute_ic_scores(df: pd.DataFrame, rsg: RobustSignalGenerator) -> dict:
 
 def precompute_ic_scores(df: pd.DataFrame, rsg: RobustSignalGenerator) -> dict:
     """预先计算一次 IC 分数，供多次回测复用"""
+    if not getattr(rsg, "models", None):
+        predictor = PredictorAdapter(AIModelPredictor(MODEL_PATHS))
+        rsg.predictor = predictor
+        rsg.models = predictor.ai_predictor.models
     return compute_ic_scores(df, rsg)
 
 


### PR DESCRIPTION
## Summary
- 自动在缺少模型时加载 AIModelPredictor 并包装为 PredictorAdapter
- 新增单元测试，验证未预加载模型也能计算 IC 分数

## Testing
- `pytest -q tests` *(failed: 多个现有测试未通过)*
- `pytest tests/test_param_search.py::test_precompute_ic_scores_load_models -q`


------
https://chatgpt.com/codex/tasks/task_e_689f39784cd0832a9b1db625798e42f6