### PR TITLE
feat: duplicate model paths for scheduler

### DIFF
--- a/quant_trade/utils/config.yaml
+++ b/quant_trade/utils/config.yaml
@@ -138,6 +138,23 @@ models:
     rise: ""
     drawdown: ""
 
+model_paths:
+  1h:
+    cls: models/model_1h_cls.pkl
+    vol: models/model_1h_vol.pkl
+    rise: models/model_1h_rise.pkl
+    drawdown: models/model_1h_drawdown.pkl
+  4h:
+    cls: models/model_4h_cls.pkl
+    vol: models/model_4h_vol.pkl
+    rise: models/model_4h_rise.pkl
+    drawdown: models/model_4h_drawdown.pkl
+  d1:
+    cls: ""
+    vol: ""
+    rise: ""
+    drawdown: ""
+
 
 feature_cols:
   1h:


### PR DESCRIPTION
## Summary
- add `model_paths` configuration mirroring `models` so scheduler can load models

## Testing
- `pytest -q tests` *(fails: assert 0.0 == 0.004596181211551101 ± 4.6e-09, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689f4313b544832aba27354c90827b7e