### PR TITLE
Inject RiskManager into signal generator instances

### DIFF
--- a/backtests/calibrate_thresholds.py
+++ b/backtests/calibrate_thresholds.py
@@ -13,6 +13,7 @@ from quant_trade.signal.core import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "quant_trade" / "utils" / "config.yaml"
 MIN_TRADES = 30
@@ -70,6 +71,7 @@ def _evaluate(
 ) -> Tuple[float, Dict[str, float]]:
     """使用给定参数评估指标并返回综合得分."""
     sg = RobustSignalGenerator(rsg_cfg)
+    sg.risk_manager = RiskManager()
     sg.ai_dir_eps = params["ai_dir_eps"]
     sg.signal_threshold_cfg["base_th"] = params["base_th"]
     sg.signal_threshold_cfg["dynamic_quantile"] = params["dynamic_quantile"]

--- a/optimize_params.py
+++ b/optimize_params.py
@@ -11,6 +11,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGeneratorConfig,
 )
 from quant_trade.param_search import precompute_ic_scores, run_single_backtest
+from quant_trade.risk_manager import RiskManager
 
 
 KEYS = ["ai", "trend", "momentum", "volatility", "volume", "sentiment", "funding"]
@@ -63,6 +64,7 @@ def optimize_params(
 
     rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
     sg = RobustSignalGenerator(rsg_cfg)
+    sg.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
     ic_scores = precompute_ic_scores(df, sg)
     history_window = cfg.get("history_window", 679)
 

--- a/quant_trade/backtester.py
+++ b/quant_trade/backtester.py
@@ -11,6 +11,7 @@ from quant_trade.robust_signal_generator import (
 from quant_trade.utils.helper import calc_features_raw, collect_feature_cols
 from quant_trade.logging import get_logger
 from quant_trade.json_logger import log_signal
+from quant_trade.risk_manager import RiskManager
 from quant_trade.backtest.backtester import ExecutionPolicy, execute_signal
 from quant_trade.slippage_model import SlippageModel
 from quant_trade.signal.decision import DecisionConfig, decide_signal
@@ -273,6 +274,7 @@ def run_backtest(
     all_symbols = df['symbol'].unique().tolist()
     rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
     sg = RobustSignalGenerator(rsg_cfg)
+    sg.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
     if cvar_alpha is not None:
         sg.cvar_alpha = cvar_alpha
 

--- a/quant_trade/generate_signal_from_db.py
+++ b/quant_trade/generate_signal_from_db.py
@@ -12,6 +12,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 from quant_trade.utils.robust_scaler import load_scaler_params_from_json
 from quant_trade.feature_loader import (
     load_latest_klines,
@@ -45,6 +46,7 @@ def main(symbol: str = "ETHUSDT") -> None:
 
     rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
     sg = RobustSignalGenerator(rsg_cfg)
+    sg.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
     sg.set_symbol_categories(categories)
 
     results = []

--- a/quant_trade/param_search.py
+++ b/quant_trade/param_search.py
@@ -26,6 +26,7 @@ from quant_trade.ai_model_predictor import AIModelPredictor
 from quant_trade.signal import PredictorAdapter
 from quant_trade.utils.db import load_config, connect_mysql
 from quant_trade.logging import get_logger
+from quant_trade.risk_manager import RiskManager
 
 logger = get_logger(__name__)
 
@@ -341,6 +342,7 @@ def run_param_search(
 
     rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
     sg = RobustSignalGenerator(rsg_cfg)
+    sg.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
     cached_ics = [precompute_ic_scores(tr, sg) for tr, _ in splits]
     base_delta = sg.delta_params.copy()
     if method == "grid":
@@ -432,6 +434,7 @@ def run_param_search(
                 iter_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
                 iter_cfg.delta_params = delta_params
                 sg_iter = RobustSignalGenerator(iter_cfg)
+                sg_iter.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
                 tot_ret, sharpe, trade_count = run_single_backtest(
                     val_df,
                     base_weights,
@@ -551,6 +554,7 @@ def run_param_search(
                 iter_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
                 iter_cfg.delta_params = delta_params
                 sg_iter = RobustSignalGenerator(iter_cfg)
+                sg_iter.risk_manager = RiskManager(**cfg.get("risk_manager", {}))
                 tot_ret, sharpe, trade_count = run_single_backtest(
                     val_df,
                     base_weights,

--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -288,6 +288,15 @@ class Scheduler:
             self.cfg = load_config()
             rsg_cfg = RobustSignalGeneratorConfig.from_cfg(self.cfg)
             self.sg = RobustSignalGenerator(rsg_cfg)
+            rm_cfg = self.cfg.get("optimize_weights", {})
+            rm_kwargs = {}
+            if isinstance(rm_cfg, dict):
+                if "cap" in rm_cfg:
+                    rm_kwargs["cap"] = rm_cfg["cap"]
+                if "max_weight" in rm_cfg:
+                    rm_kwargs["max_weight"] = rm_cfg["max_weight"]
+            from quant_trade.risk_manager import RiskManager
+            self.sg.risk_manager = RiskManager(**rm_kwargs)
             self.sg.base_weights = self.cfg.get("ic_scores", {}).get("base_weights", {})
             categories = load_symbol_categories(self.engine)
             self.sg.set_symbol_categories(categories)

--- a/quant_trade/tests/test_utils.py
+++ b/quant_trade/tests/test_utils.py
@@ -5,6 +5,7 @@ import types
 
 from quant_trade.utils.lru import LRU
 from quant_trade.robust_signal_generator import RobustSignalGenerator
+from quant_trade.risk_manager import RiskManager
 from quant_trade.signal import (
     ThresholdingDynamic,
     PredictorAdapter,
@@ -17,6 +18,7 @@ from quant_trade.signal import (
 
 def make_dummy_rsg():
     rsg = RobustSignalGenerator.__new__(RobustSignalGenerator)
+    rsg.risk_manager = RiskManager()
     rsg._factor_cache = LRU(300)
     rsg._ai_score_cache = LRU(300)
     rsg.factor_scorer = FactorScorerImpl(rsg)

--- a/tests/signal/test_golden_batch.py
+++ b/tests/signal/test_golden_batch.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, RobustSignalGeneratorConfig
+from quant_trade.risk_manager import RiskManager
 import quant_trade.signal.core as core
 
 FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures"
@@ -36,6 +37,7 @@ def test_golden_batch(cases_data, monkeypatch):
         feature_cols_d1=[],
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
 
     feats_1h = [c["features"]["1h"] for c in cases_data]
     feats_4h = [c["features"]["4h"] for c in cases_data]

--- a/tests/signal/test_golden_single.py
+++ b/tests/signal/test_golden_single.py
@@ -7,6 +7,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 import quant_trade.signal.core as core
 
 FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures"
@@ -36,6 +37,7 @@ def test_golden_single(case_data, monkeypatch):
         feature_cols_d1=[],
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
 
     features = case_data["features"]
     raw = case_data["raw"]
@@ -92,6 +94,7 @@ def test_generate_signal_structure_consistency(case_data, monkeypatch):
         feature_cols_d1=[],
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
 
     features = case_data["features"]
     raw = case_data["raw"]

--- a/tests/test_cache_lru.py
+++ b/tests/test_cache_lru.py
@@ -3,6 +3,7 @@ import threading
 from quant_trade.utils.lru import LRU
 from quant_trade.signal.ai_inference import get_period_ai_scores
 from quant_trade.robust_signal_generator import RobustSignalGenerator
+from quant_trade.risk_manager import RiskManager
 
 
 class DummyPredictor:
@@ -19,6 +20,7 @@ class DummyPredictor:
 
 def test_ai_cache_hit_and_eviction_and_init():
     rsg = RobustSignalGenerator()
+    rsg.risk_manager = RiskManager()
     assert isinstance(rsg._factor_cache, LRU)
     assert isinstance(rsg._ai_score_cache, LRU)
     assert rsg._factor_cache.maxsize == 300

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -10,6 +10,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 
 
 def _write_cfg(tmp_path: Path, cfg: dict) -> Path:
@@ -31,7 +32,9 @@ def _make_rsg(tmp_path: Path, cfg: dict):
         "enable_ai": False,
     }
     config_obj = RobustSignalGeneratorConfig.from_cfg(init_cfg, cfg_path)
-    return RobustSignalGenerator(config_obj)
+    rsg = RobustSignalGenerator(config_obj)
+    rsg.risk_manager = RiskManager()
+    return rsg
 
 
 def test_cfg_validation_success(tmp_path):

--- a/tests/test_delta_boost.py
+++ b/tests/test_delta_boost.py
@@ -2,6 +2,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 
 
 def _fake_feat(**kv):
@@ -16,6 +17,7 @@ def test_delta_boost():
         feature_cols_d1=[],
     )
     g = RobustSignalGenerator(cfg)
+    g.risk_manager = RiskManager()
     f1 = _fake_feat(rsi_1h=50, macd_hist_1h=0.001)
     f2 = _fake_feat(rsi_1h=57, macd_hist_1h=0.003)
     g._prev_raw["1h"] = f1

--- a/tests/test_get_ai_score.py
+++ b/tests/test_get_ai_score.py
@@ -4,6 +4,7 @@ import pytest
 from sklearn.dummy import DummyClassifier
 
 from quant_trade.robust_signal_generator import RobustSignalGenerator, RobustSignalGeneratorConfig
+from quant_trade.risk_manager import RiskManager
 
 
 def build_dummy_model(constant, features, path):
@@ -28,6 +29,7 @@ def test_get_ai_score_auto_features(tmp_path):
         feature_cols_d1=[],
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
 
     df = pd.DataFrame({"f1": [0.5], "f2": [0.1]})
     score = rsg.predictor.get_ai_score(df, rsg.models["1h"]["up"], rsg.models["1h"]["down"])

--- a/tests/test_phase_config.py
+++ b/tests/test_phase_config.py
@@ -1,6 +1,7 @@
 import yaml
 import pytest
 from quant_trade.robust_signal_generator import RobustSignalGenerator, RobustSignalGeneratorConfig
+from quant_trade.risk_manager import RiskManager
 
 
 def test_update_market_phase_uses_config(tmp_path, monkeypatch):
@@ -19,6 +20,7 @@ def test_update_market_phase_uses_config(tmp_path, monkeypatch):
         config_path=cfg_path,
     )
     rsg = RobustSignalGenerator(rsg_cfg)
+    rsg.risk_manager = RiskManager()
     monkeypatch.setattr(
         "quant_trade.market_phase.get_market_phase", lambda engine: {"phase": "bull"}
     )
@@ -47,6 +49,7 @@ def test_update_phase_dir_mult(tmp_path, monkeypatch):
         config_path=cfg_path,
     )
     rsg = RobustSignalGenerator(rsg_cfg)
+    rsg.risk_manager = RiskManager()
     monkeypatch.setattr(
         "quant_trade.market_phase.get_market_phase", lambda engine: {"phase": "bear"}
     )

--- a/tests/test_phase_dir_mult.py
+++ b/tests/test_phase_dir_mult.py
@@ -5,6 +5,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 
 
 def setup_simple_rsg(tmp_path, monkeypatch, phase, mult_cfg, score):
@@ -18,6 +19,7 @@ def setup_simple_rsg(tmp_path, monkeypatch, phase, mult_cfg, score):
         config_path=cfg_path,
     )
     rsg = RobustSignalGenerator(rsg_cfg)
+    rsg.risk_manager = RiskManager()
     monkeypatch.setattr(
         "quant_trade.market_phase.get_market_phase",
         lambda engine: {"phase": phase},

--- a/tests/test_rsg_load_path.py
+++ b/tests/test_rsg_load_path.py
@@ -3,6 +3,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGenerator,
     RobustSignalGeneratorConfig,
 )
+from quant_trade.risk_manager import RiskManager
 
 
 def test_model_path_resolution(tmp_path, monkeypatch):
@@ -15,6 +16,7 @@ def test_model_path_resolution(tmp_path, monkeypatch):
         feature_cols_d1=[],
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
     assert "cls" in rsg.models.get("1h", {})
     assert hasattr(rsg.models["1h"]["cls"]["pipeline"], "predict")
     rsg.update_weights()
@@ -45,6 +47,7 @@ ic_scores:
         config_path=cfg_path,
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
     total = 1 + 1 + 2 + 2 + 1 + 1 + 3
     expected = {
         "ai": 1 / total,
@@ -77,6 +80,7 @@ signal_threshold:
         config_path=cfg_path,
     )
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
     assert rsg.signal_threshold_cfg["base_th"] == pytest.approx(0.2)
     rsg.update_weights()
 

--- a/tests/test_voting_model.py
+++ b/tests/test_voting_model.py
@@ -8,6 +8,7 @@ from quant_trade.robust_signal_generator import (
     RobustSignalGeneratorConfig,
 )
 import quant_trade.robust_signal_generator as rsg_mod
+from quant_trade.risk_manager import RiskManager
 
 
 def test_voting_model_train_and_predict(tmp_path):
@@ -49,6 +50,7 @@ def test_compute_vote_behavior(monkeypatch, prob, weak_vote, strong_confirm):
 
     cfg = RobustSignalGeneratorConfig(prob_margin=0.1, strong_prob_th=0.8)
     rsg = RobustSignalGenerator(cfg)
+    rsg.risk_manager = RiskManager()
 
     class DummyModel:
         feature_cols = VotingModel.FEATURE_COLS


### PR DESCRIPTION
## Summary
- Ensure every `RobustSignalGenerator` instance receives a `RiskManager` after construction
- Provide `RiskManager` in test utilities to avoid bare signal generators

## Testing
- `python -m pytest -q tests` *(fails: TypeError: combine_score() missing 1 required positional argument: 'weights')*

------
https://chatgpt.com/codex/tasks/task_e_689f472393dc832aa1f6f46acd417f75