### PR TITLE
精简配置并增强 RobustSignalGenerator 兼容性

### DIFF
--- a/quant_trade/backtester.py
+++ b/quant_trade/backtester.py
@@ -37,7 +37,7 @@ DECISION_CONFIG = DecisionConfig.from_dict(_cfg.get("signal", {}))
 TEMP_MODEL = TemperatureModel(_cfg.get("calibration", {}).get("temperature", 1.0))
 
 # 预训练模型路径（从 config.yaml 读取）
-_model_cfg = _cfg.get("models", {})
+_model_cfg = _cfg.get("model_paths") or _cfg.get("models", {})
 MODEL_PATHS = {
     (period, tag): path
     for period, tags in _model_cfg.items()

--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -66,13 +66,32 @@ class RobustSignalGeneratorConfig:
         cfg: Mapping[str, Any],
         cfg_path: str | Path | None = None,
     ) -> "RobustSignalGeneratorConfig":
+        vs_cfg = cfg.get("vote_system", {})
+        model_paths = cfg.get("model_paths") or cfg.get("models", {})
+
+        def _extract(period: str) -> list[str]:
+            direct = cfg.get(f"feature_cols_{period}")
+            if direct:
+                return list(direct)
+            fc = cfg.get("feature_cols", {}).get(period, [])
+            if isinstance(fc, Mapping):
+                cols: list[str] = []
+                for v in fc.values():
+                    if isinstance(v, list):
+                        cols.extend(v)
+                return cols
+            return list(fc)
+
+        fc_1h = _extract("1h")
+        fc_4h = _extract("4h")
+        fc_d1 = _extract("d1")
         return cls(
-            model_paths=cfg.get("model_paths", {}),
-            feature_cols_1h=cfg.get("feature_cols_1h", []),
-            feature_cols_4h=cfg.get("feature_cols_4h", []),
-            feature_cols_d1=cfg.get("feature_cols_d1", []),
-            prob_margin=cfg.get("prob_margin", 0.08),
-            strong_prob_th=cfg.get("strong_prob_th", 0.8),
+            model_paths=model_paths,
+            feature_cols_1h=fc_1h,
+            feature_cols_4h=fc_4h,
+            feature_cols_d1=fc_d1,
+            prob_margin=cfg.get("prob_margin", vs_cfg.get("prob_margin", 0.08)),
+            strong_prob_th=cfg.get("strong_prob_th", vs_cfg.get("strong_prob_th", 0.8)),
             config_path=cfg_path,
         )
 

--- a/quant_trade/run_scheduler.py
+++ b/quant_trade/run_scheduler.py
@@ -118,7 +118,7 @@ class Scheduler:
         )
         rsg_cfg = RobustSignalGeneratorConfig.from_cfg(cfg)
         self.sg = RobustSignalGenerator(rsg_cfg)
-        model_paths = cfg.get("model_paths", {})
+        model_paths = cfg.get("model_paths") or cfg.get("models", {})
         ai_predictor = AIModelPredictor(model_paths)
         self.sg.predictor = PredictorAdapter(ai_predictor)
         self.sg.models = self.sg.predictor.ai_predictor.models

--- a/quant_trade/utils/config.yaml
+++ b/quant_trade/utils/config.yaml
@@ -8,7 +8,6 @@ enable_ai: true
 # 设置为 false 可跳过因子贡献度计算以提升回测速度
 enable_factor_breakdown: false
 max_stop_loss_pct: 0.05
-trailing_stop_pct: 0.03
 risk_budget_per_trade: 0.01
 cv:
   embargo: 1  # 交叉验证时的隔离步数(1~2 个 horizon)
@@ -120,23 +119,6 @@ feature_selector:
   - future_max_rise_d1
   - future_max_drawdown_d1
   top_n: 50             # 每周期保留前 N
-
-models:
-  1h:
-    cls: models/model_1h_cls.pkl
-    vol: models/model_1h_vol.pkl
-    rise: models/model_1h_rise.pkl
-    drawdown: models/model_1h_drawdown.pkl
-  4h:
-    cls: models/model_4h_cls.pkl
-    vol: models/model_4h_vol.pkl
-    rise: models/model_4h_rise.pkl
-    drawdown: models/model_4h_drawdown.pkl
-  d1:
-    cls: ""
-    vol: ""
-    rise: ""
-    drawdown: ""
 
 model_paths:
   1h:


### PR DESCRIPTION
## Summary
- 兼容 `model_paths`、`feature_cols` 与 `vote_system` 新旧字段
- 删除配置中的 `trailing_stop_pct` 与 `models` 并更新加载逻辑
- 文档说明新的实例化方式及旧字段迁移

## Testing
- `pytest -q tests` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c34ecf4832a95e37d3f367c136b