### PR TITLE
feat: expose predictor models and calibrators

### DIFF
--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -218,6 +218,10 @@ class RobustSignalGenerator:
                 fused *= self.phase_dir_mult.get("short", 1.0)
             return self._calc_position_and_sl_tp(fused, risk.get("base_th"), direction, **data)
 
+        pred = getattr(self, "predictor", None)
+        kwargs.setdefault("predictor", pred)
+        kwargs.setdefault("models", getattr(pred, "models", {}))
+        kwargs.setdefault("calibrators", getattr(pred, "calibrators", {}))
         kwargs.setdefault("ai_score_cache", self._ai_score_cache)
         return core.generate_signal(
             features_1h,

--- a/quant_trade/signal/predictor_adapter.py
+++ b/quant_trade/signal/predictor_adapter.py
@@ -13,6 +13,14 @@ class PredictorAdapter:
     def __init__(self, ai_predictor: AIModelPredictor | None) -> None:
         self.ai_predictor = ai_predictor
 
+    @property
+    def models(self) -> dict:
+        return self.ai_predictor.models if self.ai_predictor else {}
+
+    @property
+    def calibrators(self) -> dict:
+        return self.ai_predictor.calibrators if self.ai_predictor else {}
+
     def get_ai_score(self, features: Any, *args: Any, **kwargs: Any) -> float:
         if isinstance(features, pd.DataFrame):
             if len(features.index):


### PR DESCRIPTION
## Summary
- expose `models` and `calibrators` from `PredictorAdapter`
- forward predictor metadata in `RobustSignalGenerator.generate_signal`

## Testing
- `pytest -q tests/test_rsg_batch_scoring.py`
- `python - <<'PY'
from quant_trade.robust_signal_generator import RobustSignalGenerator
from quant_trade.signal.predictor_adapter import PredictorAdapter
class DummyAI:
    def __init__(self):
        self.models={'1h':{'up':{'features':[]},'down':{'features':[]}}}
        self.calibrators={'1h':{'up':None,'down':None}}
    def get_ai_score(self,features,up,down,*a,**k):
        return 0.42
pred=PredictorAdapter(DummyAI())
rsg=RobustSignalGenerator(); rsg.predictor=pred; rsg.models=pred.models
print(rsg.generate_signal_batch([{'a':1}],[{'a':1}],[{'a':1}]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689fc3a5fef0832a904967a0325a2e38