### PR TITLE
chore: configure ai periods

### DIFF
--- a/quant_trade/utils/config.yaml
+++ b/quant_trade/utils/config.yaml
@@ -9,6 +9,8 @@ enable_ai: true
 enable_factor_breakdown: false
 max_stop_loss_pct: 0.05
 risk_budget_per_trade: 0.01
+ai:
+  enabled_periods: ["1h", "4h"]
 cv:
   embargo: 1  # 交叉验证时的隔离步数(1~2 个 horizon)
 binance:


### PR DESCRIPTION
## Summary
- specify AI-enabled periods in config

## Testing
- `pytest -q tests` (failed: TypeError and AssertionError)


------
https://chatgpt.com/codex/tasks/task_e_689fcbb9b294832ab0f641d813e62122