### PR TITLE
refactor: use periods constant for multi-period funcs

### DIFF
--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -83,6 +83,7 @@ def generate_signal(
     period_features = {"1h": features_1h, "4h": features_4h, "d1": features_d1}
     if features_15m is not None:
         period_features["15m"] = features_15m
+    periods = ["1h", "4h", "d1"]
 
     # 1. 因子分
     factor_scores = _safe_factor_scores(period_features)
@@ -99,7 +100,7 @@ def generate_signal(
 
     # 将因子分与 AI 分简单相加得到每周期的综合得分
     combined = {}
-    for p in ("1h", "4h", "d1"):
+    for p in periods:
         fs = factor_scores.get(p, {})
         f_val = float(np.mean(list(fs.values()))) if fs else 0.0
         combined[p] = ai_scores.get(p, 0.0) + f_val

--- a/quant_trade/signal/multi_period_fusion.py
+++ b/quant_trade/signal/multi_period_fusion.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 import numpy as np
 
+PERIODS: Tuple[str, str, str] = ("1h", "4h", "d1")
 
 def consensus_check(s1: float, s2: float, s3: float, min_agree: int = 2) -> int:
     """多周期方向共振检查。
@@ -81,11 +82,7 @@ def get_ic_weights(core) -> Tuple[float, float, float]:
         return weights
 
     ic_scores = getattr(core, "ic_scores", {})
-    ic_periods = {
-        "1h": ic_scores.get("1h", 1.0),
-        "4h": ic_scores.get("4h", 1.0),
-        "d1": ic_scores.get("d1", 1.0),
-    }
+    ic_periods = {p: ic_scores.get(p, 1.0) for p in PERIODS}
     weights = core.get_ic_period_weights(ic_periods)
     if cache is not None:
         cache.set("ic_weights", weights)
@@ -101,7 +98,8 @@ def fuse_scores(
     conflict_mult: float = 0.7,
 ) -> tuple[float, bool, bool, bool]:
     """按照多周期共振逻辑融合得分。"""
-    s1, s4, sd = scores["1h"], scores["4h"], scores["d1"]
+    periods = PERIODS
+    s1, s4, sd = (scores[p] for p in periods)
     w1, w4, wd = ic_weights
 
     consensus_dir = consensus_check(s1, s4, sd)


### PR DESCRIPTION
## Summary
- use shared PERIODS tuple in multi-period fusion helpers
- update vote fusion to iterate only through PERIODS
- rely on PERIODS when combining per-period scores

## Testing
- `pytest -q tests` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'ThresholdParams')*


------
https://chatgpt.com/codex/tasks/task_e_689fd0718a40832abcb71c46faf077da