### PR TITLE
feat: limit risk period data

### DIFF
--- a/quant_trade/robust_signal_generator.py
+++ b/quant_trade/robust_signal_generator.py
@@ -613,6 +613,10 @@ class RobustSignalGenerator:
         score_mult = risk_info.get("score_mult")
         pos_mult = risk_info.get("pos_mult")
         if score_mult is None or pos_mult is None:
+            periods = tuple(
+                p for p in getattr(self, "enabled_periods", ["1h", "4h", "d1"])
+                if p in ("1h", "4h", "d1")
+            )
             sm, pm, reasons = self.risk_filters.apply_risk_filters(
                 score_for_thresholding,
                 logic_score,
@@ -631,6 +635,7 @@ class RobustSignalGenerator:
                 global_metrics,
                 symbol,
                 dyn_base=None,
+                periods=periods,
             )
             score_mult = 1.0 if score_mult is None else score_mult
             pos_mult = 1.0 if pos_mult is None else pos_mult

--- a/tests/test_risk_filters.py
+++ b/tests/test_risk_filters.py
@@ -111,3 +111,50 @@ def test_oi_overheat_reason():
         cache={"oi_overheat": True},
     )
     assert RiskReason.OI_OVERHEAT.value in reasons
+
+
+def test_periods_excludes_d1():
+    rf = make_filters()
+    cache = base_cache()
+    score_mult_d1, _pos_mult, _ = rf.apply_risk_filters(
+        fused_score=1.0,
+        logic_score=1.0,
+        env_score=0.0,
+        std_1h={},
+        std_4h={},
+        std_d1={},
+        raw_f1h={},
+        raw_f4h={},
+        raw_fd1={"funding_rate_d1": -0.01},
+        vol_preds={"1h": 0.0},
+        open_interest=None,
+        all_scores_list=None,
+        rev_dir=0,
+        cache=cache,
+        global_metrics=None,
+        symbol="BTC",
+        dyn_base=None,
+    )
+    cache2 = base_cache()
+    score_mult_no_d1, _pos_mult, _ = rf.apply_risk_filters(
+        fused_score=1.0,
+        logic_score=1.0,
+        env_score=0.0,
+        std_1h={},
+        std_4h={},
+        std_d1={},
+        raw_f1h={},
+        raw_f4h={},
+        raw_fd1={"funding_rate_d1": -0.01},
+        vol_preds={"1h": 0.0},
+        open_interest=None,
+        all_scores_list=None,
+        rev_dir=0,
+        cache=cache2,
+        global_metrics=None,
+        symbol="BTC",
+        dyn_base=None,
+        periods=("1h", "4h"),
+    )
+    assert score_mult_d1 < 1.0
+    assert score_mult_no_d1 == 1.0


### PR DESCRIPTION
## Summary
- 支持在风险过滤器中传入 `periods`，忽略未启用周期的指标
- `RobustSignalGenerator` 调用风险过滤器时遵从启用周期
- 增加测试覆盖，确保剔除 `d1` 后不受其影响

## Testing
- `pytest -q tests` *(failed: extensive failures across suite)*
- `pytest -q tests/test_risk_filters.py`

------
https://chatgpt.com/codex/tasks/task_e_689fd3da84ec832ab80f10b2eda98cf6