### PR TITLE
feat: handle disabled periods in results

### DIFF
--- a/quant_trade/signal/engine.py
+++ b/quant_trade/signal/engine.py
@@ -251,6 +251,7 @@ class SignalEngine:
         )
         if result is None:
             return None
+        result = self.rsg._fill_disabled_periods(result)
         result["position_size"] = min(
             result.get("position_size", 0.0), self.rsg.max_position
         )


### PR DESCRIPTION
## Summary
- ensure result dictionaries include all defined periods
- fill disabled periods with `None` during signal generation and engine run

## Testing
- `pytest -q` *(fails: combine_score() missing 1 required positional argument: 'weights')*

------
https://chatgpt.com/codex/tasks/task_e_689fd6639178832a960cd995a98a63d4