### PR TITLE
feat: 引入AI与因子权重并支持IC动态调整

### DIFF
--- a/config/signal.yaml
+++ b/config/signal.yaml
@@ -1,0 +1,3 @@
+w_ai: 1.0
+w_factor: 1.0
+ic_threshold: 0.0


### PR DESCRIPTION
## Summary
- add `w_ai` and `w_factor` config with optional IC threshold
- weight AI and factor scores in `generate_signal`
- adjust weights using IC/backtest metrics when below threshold

## Testing
- `pytest -q tests` *(fails: TypeError, AssertionError and others)*

------
https://chatgpt.com/codex/tasks/task_e_689fdb2a529c832a93d4410981e0cd9b