### PR TITLE
feat: enhance multi-period fusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,11 @@ risk_adjust_threshold: null     # 若为 null，将根据历史得分计算阈�
 risk_th_quantile: 0.6           # 自适应阈值的分位数
 veto_conflict_count: 2         # funding 冲突达到此数目直接放弃信号
 min_trend_align: 2             # 趋势方向至少在 N 个周期保持一致
+cycle_weight:
+  strong: 1.2
+  weak: 0.8
+  opposite: 0.6
+  conflict: 0.7
 protection_limits:
   risk_score: 1.0    # 允许的风险得分上限
 crowding_limit: 1.05     # 允许的拥挤度上限
@@ -170,6 +175,9 @@ crowding_protection:
 - `max_stop_loss_pct` 控制单笔交易最大的允许亏损比例。
 - `risk_budget_per_trade` 定义每笔交易可占用的风险预算上限。
 - `crowding_protection` 用于监控市场同向拥挤度并在过热时暂停开仓。
+- `cycle_weight` 可根据市场波动或单边趋势调整多周期融合时的加权系数，
+  其中 `strong/weak/opposite/conflict` 分别对应全周期共振、部分共振、方向相反
+  及无共识时的衰减倍率。
 - `risk_adjust.factor` 控制风险值对 `fused_score` 的削减力度，公式为
   `fused_score *= 1 - factor * risk_score`，一般建议取值在 `0.1`～`0.3` 之间。
 

--- a/quant_trade/signal/core.py
+++ b/quant_trade/signal/core.py
@@ -123,8 +123,9 @@ def generate_signal(
 
     # 3. 多周期融合
     ic_weights: Tuple[float, float, float] = (1.0, 1.0, 1.0)
+    ic_periods = {p: ic_stats.get(p) for p in periods} if ic_stats else None
     fused_score, consensus_all, consensus_14, consensus_4d1 = multi_period_fusion.fuse_scores(
-        combined, ic_weights, False
+        combined, ic_weights, False, ic_stats=ic_periods, min_agree=2
     )
 
     # 4. 动态阈值计算

--- a/quant_trade/signal/fusion_rule.py
+++ b/quant_trade/signal/fusion_rule.py
@@ -89,4 +89,6 @@ class FusionRuleBased:
             strong_confirm_4h,
             cycle_weight=self.core.cycle_weight,
             conflict_mult=getattr(self.core, "conflict_mult", 0.7),
+            ic_stats=getattr(self.core, "ic_cycle_scores", None),
+            min_agree=getattr(self.core, "min_trend_align", 2),
         )

--- a/tests/signal/test_multi_period_fusion_basic.py
+++ b/tests/signal/test_multi_period_fusion_basic.py
@@ -17,3 +17,23 @@ def test_conflict_penalty():
     fused, c_all, c_14, c_4d1 = fuse_scores(scores, weights, False)
     assert not (c_all or c_14 or c_4d1)
     assert fused == pytest.approx(0.5 * 0.7)
+
+
+def test_dynamic_ic_adjusts_weights():
+    scores = {"1h": 0.5, "4h": 0.2, "d1": 0.1}
+    weights = (0.4, 0.4, 0.2)
+    ic_stats = {"1h": 0.0, "4h": 1.0, "d1": -0.5}
+    fused, c_all, _, _ = fuse_scores(scores, weights, False, ic_stats=ic_stats)
+    assert c_all
+    # weights after adjustment: 0.4,0.8,0.1 -> normalized to ~0.3077,0.6154,0.0769
+    expected = 0.3077 * 0.5 + 0.6154 * 0.2 + 0.0769 * 0.1
+    expected *= 1.1
+    assert fused == pytest.approx(expected, rel=1e-3)
+
+
+def test_ignore_period_with_zero_weight():
+    scores = {"1h": 0.5, "4h": 0.5, "d1": -0.9}
+    weights = (0.5, 0.5, 0.0)
+    fused, c_all, c_14, c_4d1 = fuse_scores(scores, weights, False)
+    assert c_all and not c_14 and not c_4d1
+    assert fused == pytest.approx(0.55)

--- a/tests/test_new_funcs.py
+++ b/tests/test_new_funcs.py
@@ -122,10 +122,11 @@ def test_fuse_multi_cycle():
 
 def test_fuse_multi_cycle_conflict_mult():
     rsg = make_dummy_rsg()
+    rsg.cycle_weight['conflict'] = 0.5
+    rsg.conflict_mult = 0.9
     scores = {'1h': 0.2, '4h': -0.1, 'd1': 0.1}
     fused, a, b, c = rsg.fuse_multi_cycle(scores, (0.5, 0.3, 0.2), False)
-    expected = scores['1h'] * getattr(rsg, 'conflict_mult', 0.7)
-    assert fused == pytest.approx(expected)
+    assert fused == pytest.approx(0.2 * 0.5)
     assert not (a or b or c)
 
 


### PR DESCRIPTION
## Summary
- add dynamic IC-based weighting and configurable consensus threshold for score fusion
- allow custom cycle weights including conflict scaling and zero-weight periods
- document cycle_weight options in README

## Testing
- `pytest -q tests/signal/test_multi_period_fusion_basic.py`
- `pytest tests/test_new_funcs.py::test_fuse_multi_cycle_conflict_mult -vv`
- `pytest -q tests` *(fails: numerous missing attributes and assertion mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_689fddd7b2b0832a86943c238c289fde