### PR TITLE
feat: add fusion configuration

### DIFF
--- a/config/signal.yaml
+++ b/config/signal.yaml
@@ -15,3 +15,11 @@ cache:
   ttl: 3600
 batch:
   max_workers: 4
+fusion:
+  min_agree: 2
+  conflict_mult: 0.7
+  cycle_weight:
+    strong: 1.0
+    weak: 1.0
+    opposite: 1.0
+    conflict: 0.7

--- a/quant_trade/signal/multi_period_fusion.py
+++ b/quant_trade/signal/multi_period_fusion.py
@@ -159,23 +159,31 @@ def fuse_scores(
         and ("1h" not in active or signs["1h"] != signs["4h"])
     )
 
-    cw = cycle_weight or {}
+    cw_defaults = {
+        "strong": 1.0,
+        "weak": 1.0,
+        "opposite": 1.0,
+        "conflict": conflict_mult,
+    }
+    if cycle_weight:
+        cw_defaults.update(cycle_weight)
+    cw = cw_defaults
     if consensus_all:
         fused = w1 * s1 + w4 * s4 + wd * sd
         conf = 1.1
         if strong_confirm_4h:
             conf *= 1.05
-        fused *= cw.get("strong", 1.0)
+        fused *= cw["strong"]
     elif consensus_14:
         total = w1 + w4
         fused = (w1 / total) * s1 + (w4 / total) * s4
         conf = 0.9
-        fused *= cw.get("weak", 1.0)
+        fused *= cw["weak"]
     elif consensus_4d1:
         total = w4 + wd
         fused = (w4 / total) * s4 + (wd / total) * sd
         conf = 0.9
-        fused *= cw.get("weak", 1.0)
+        fused *= cw["weak"]
     else:
         fused = s1
         conf = 1.0
@@ -188,8 +196,8 @@ def fuse_scores(
             or (np.sign(sd) != 0 and np.sign(s1) != np.sign(sd))
         )
     ):
-        fused_score *= cw.get("opposite", 1.0)
-    conflict_mult = cw.get("conflict", conflict_mult)
+        fused_score *= cw["opposite"]
+    conflict_mult = cw["conflict"]
     if not (consensus_all or consensus_14 or consensus_4d1):
         fused_score *= conflict_mult
     return fused_score, consensus_all, consensus_14, consensus_4d1

--- a/tests/signal/test_generate_signal_fusion_config.py
+++ b/tests/signal/test_generate_signal_fusion_config.py
@@ -1,0 +1,58 @@
+from quant_trade.signal import core
+
+
+def test_generate_signal_reads_fusion_config(monkeypatch):
+    cfg = {
+        "fusion": {
+            "min_agree": 3,
+            "conflict_mult": 0.5,
+            "cycle_weight": {
+                "strong": 1.2,
+                "weak": 0.8,
+                "opposite": 0.6,
+                "conflict": 0.4,
+            },
+        }
+    }
+
+    class DummyCM:
+        def __init__(self, path):
+            pass
+
+        def get(self, key, default=None):
+            return cfg.get(key, default)
+
+    monkeypatch.setattr(core, "ConfigManager", DummyCM)
+    monkeypatch.setattr(core.features_to_scores, "get_factor_scores", lambda feats, period: {})
+    monkeypatch.setattr(
+        core.ai_inference,
+        "get_period_ai_scores",
+        lambda predictor, period_features, models, calibrators, cache=None: {"1h": 0.0, "4h": 0.0, "d1": 0.0},
+    )
+    monkeypatch.setattr(
+        core.ai_inference,
+        "get_reg_predictions",
+        lambda predictor, period_features, models: (0.0, 0.0, 0.0),
+    )
+    monkeypatch.setattr(core.dynamic_thresholds, "calc_dynamic_threshold", lambda inp: (0.0, 0.0))
+    monkeypatch.setattr(
+        core.risk_filters, "compute_risk_multipliers", lambda *a, **k: (1.0, 1.0, [], {})
+    )
+    monkeypatch.setattr(core.position_sizing, "calc_position_size", lambda *a, **k: 0.0)
+
+    captured = {}
+
+    def fake_fuse(combined, ic_weights, strong_confirm_4h, *, cycle_weight=None, conflict_mult=0.7, ic_stats=None, min_agree=2):
+        captured["cycle_weight"] = cycle_weight
+        captured["conflict_mult"] = conflict_mult
+        captured["min_agree"] = min_agree
+        return 0.0, False, False, False
+
+    monkeypatch.setattr(core.multi_period_fusion, "fuse_scores", fake_fuse)
+
+    core.generate_signal({}, {}, {})
+
+    assert captured["min_agree"] == 3
+    assert captured["conflict_mult"] == 0.5
+    assert captured["cycle_weight"] == cfg["fusion"]["cycle_weight"]
+

--- a/tests/signal/test_multi_period_fusion_basic.py
+++ b/tests/signal/test_multi_period_fusion_basic.py
@@ -37,3 +37,20 @@ def test_ignore_period_with_zero_weight():
     fused, c_all, c_14, c_4d1 = fuse_scores(scores, weights, False)
     assert c_all and not c_14 and not c_4d1
     assert fused == pytest.approx(0.55)
+
+
+def test_cycle_weight_override():
+    scores = {"1h": 0.5, "4h": -0.5, "d1": 0.2}
+    weights = (0.5, 0.3, 0.2)
+    cw = {"opposite": 0.6, "conflict": 0.4}
+    fused, c_all, c_14, c_4d1 = fuse_scores(scores, weights, False, cycle_weight=cw, conflict_mult=0.8)
+    assert not (c_all or c_14 or c_4d1)
+    assert fused == pytest.approx(0.5 * 0.6 * 0.4)
+
+
+def test_min_agree_three_requires_full_consensus():
+    scores = {"1h": 0.5, "4h": 0.5, "d1": 0.0}
+    weights = (0.5, 0.3, 0.2)
+    fused, c_all, c_14, c_4d1 = fuse_scores(scores, weights, False, min_agree=3)
+    assert not (c_all or c_14 or c_4d1)
+    assert fused == pytest.approx(0.5 * 0.7)


### PR DESCRIPTION
## Summary
- support configurable fusion parameters with min_agree, conflict_mult, and cycle weights
- add defaults for cycle weight categories in multi-period fusion
- test fusion config handling and edge cases

## Testing
- `pytest -q tests/signal/test_multi_period_fusion_basic.py tests/signal/test_generate_signal_fusion_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68a044023abc832aabbcecd5fb7bd7e6