### PR TITLE
feat: 扩展动态阈值配置与输入

### DIFF
--- a/config/signal.yaml
+++ b/config/signal.yaml
@@ -23,3 +23,11 @@ fusion:
     weak: 1.0
     opposite: 1.0
     conflict: 0.7
+
+signal_threshold:
+  base_th: 0.1
+
+dynamic_threshold:
+  smooth_window: 20
+  th_window: 60
+  th_decay: 2.0

--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -11,8 +11,8 @@ from .dynamic_thresholds import (
     DynamicThresholdParams,
     ThresholdingDynamic,
     calc_dynamic_threshold,
+    compute_dynamic_threshold,
 )
-from .robust_signal_generator import compute_dynamic_threshold
 from .thresholding_dynamic import ThresholdParams
 from .predictor_adapter import PredictorAdapter
 from .factor_scorer import FactorScorerImpl

--- a/tests/signal/test_dynamic_thresholds_basic.py
+++ b/tests/signal/test_dynamic_thresholds_basic.py
@@ -76,6 +76,26 @@ def test_atr_funding_stack():
     assert th_both == pytest.approx(th_atr + th_fund)
 
 
+def test_extra_proxies_increase_threshold():
+    sig_p = SignalThresholdParams(base_th=0, low_base=0)
+    dyn_p = DynamicThresholdParams()
+    extra = DynamicThresholdInput(
+        atr=0,
+        adx=0,
+        funding=0,
+        iv_proxy=0.02,
+        macro_proxy=0.02,
+        onchain_proxy=0.02,
+        base=0,
+        low_base=0,
+        signal_params=sig_p,
+        dynamic_params=dyn_p,
+    )
+    th, _ = calc_dynamic_threshold(extra)
+    expected = min(dyn_p.funding_cap, (0.25 * 0.02 * 3) * dyn_p.funding_mult)
+    assert th == pytest.approx(expected)
+
+
 def test_phase_mult_with_history_scores():
     params = ThresholdParams(base_th=0.0, low_base=0.0, rev_boost=0.02)
     data = {

--- a/tests/test_rsg_load_path.py
+++ b/tests/test_rsg_load_path.py
@@ -84,3 +84,30 @@ signal_threshold:
     assert rsg.signal_threshold_cfg["base_th"] == pytest.approx(0.2)
     rsg.update_weights()
 
+
+def test_dynamic_threshold_from_config(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "cfg.yml"
+    cfg_path.write_text(
+        """
+dynamic_threshold:
+  atr_mult: 5.0
+  smooth_window: 15
+  th_window: 99
+  th_decay: 1.5
+""",
+        encoding="utf-8",
+    )
+    cfg = RobustSignalGeneratorConfig(
+        model_paths={},
+        feature_cols_1h=[],
+        feature_cols_4h=[],
+        feature_cols_d1=[],
+        config_path=cfg_path,
+    )
+    rsg = RobustSignalGenerator(cfg)
+    assert rsg.dynamic_th_params.atr_mult == pytest.approx(5.0)
+    assert rsg.smooth_window == 15
+    assert rsg.th_window == 99
+    assert rsg.th_decay == pytest.approx(1.5)
+


### PR DESCRIPTION
## Summary
- 为 ThresholdParams 新增 from_cfg，统一解析信号阈值与动态阈值相关配置
- DynamicThresholdInput 支持 iv_proxy、macro_proxy、onchain_proxy 等指标
- RobustSignalGenerator 读取 smooth_window、th_window 等阈值配置
- 更新 signal.yaml 示例并补充对应单元测试

## Testing
- `pytest tests/signal/test_dynamic_thresholds_basic.py -q`
- `pytest tests/test_rsg_load_path.py::test_dynamic_threshold_from_config -q`
- `pytest -q` *(fail: 多个既有测试失败)*


------
https://chatgpt.com/codex/tasks/task_e_68a046f2e190832aa41586750ee3c03a