### PR TITLE
feat: add model signal calibration helpers

### DIFF
--- a/quant_trade/signal/model_signal.py
+++ b/quant_trade/signal/model_signal.py
@@ -7,7 +7,7 @@ into standardized trading scores.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Mapping, Sequence
 
 import numpy as np
 
@@ -35,6 +35,38 @@ class ModelSignalCfg:
     margin_min: float = 0.10
     ix_up: int = 2
     ix_down: int = 0
+
+    @classmethod
+    def from_calibration(
+        cls, data: Mapping[str, float] | Sequence[float] | None = None
+    ) -> "ModelSignalCfg":
+        """Create a config from calibration output.
+
+        Parameters
+        ----------
+        data:
+            校准结果, 可以是 ``{"center": x, "scale": y}`` 的映射,
+            也可以是 ``(center, scale[, clip])`` 的序列. 缺失的参数将
+            使用默认值。
+        """
+
+        if data is None:
+            return cls()
+        if isinstance(data, Mapping):
+            allowed = {
+                k: float(data[k])
+                for k in ("center", "scale", "clip")
+                if k in data
+            }
+            return cls(**allowed)
+
+        seq = list(data)
+        center = float(seq[0]) if len(seq) > 0 else cls.center
+        scale = float(seq[1]) if len(seq) > 1 else cls.scale
+        clip = (
+            float(seq[2]) if len(seq) > 2 else cls.clip
+        )  # type: ignore[arg-type]
+        return cls(center=center, scale=scale, clip=clip)
 
 
 def model_score_from_proba(
@@ -67,4 +99,60 @@ def model_score_from_proba(
     return None
 
 
-__all__ = ["ModelSignalCfg", "model_score_from_proba"]
+def fit_center_scale(
+    probas: Sequence[float] | np.ndarray,
+    future_returns: Sequence[float] | np.ndarray,
+    centers: Sequence[float] | None = None,
+    scales: Sequence[float] | None = None,
+    clip: float | None = 1.0,
+) -> dict[str, float | None]:
+    """Find ``center`` 与 ``scale`` 使分数与收益相关性最大。
+
+    Parameters
+    ----------
+    probas:
+        历史概率序列。
+    future_returns:
+        与 ``probas`` 对齐的未来收益序列。
+    centers, scales:
+        搜索网格, 默认为 ``[0, 1]`` 与 ``[1, 10]`` 之间的均匀网格。
+    clip:
+        评分裁剪阈值, 返回结果中会原样保存。
+
+    Returns
+    -------
+    dict
+        包含 ``center``、``scale`` 与 ``clip`` 的字典。
+    """
+
+    p = np.asarray(probas, dtype=float).reshape(-1)
+    r = np.asarray(future_returns, dtype=float).reshape(-1)
+    if p.size == 0 or r.size == 0 or p.size != r.size:
+        return {"center": 0.5, "scale": 1.0, "clip": clip}
+
+    if centers is None:
+        centers = np.linspace(0.0, 1.0, 21)
+    if scales is None:
+        scales = np.linspace(1.0, 10.0, 10)
+
+    best_corr = -1.0
+    best_c = float(centers[0])
+    best_s = float(scales[0])
+    for c in centers:
+        for s in scales:
+            score = np.tanh((p - c) * s)
+            if clip is not None:
+                score = np.clip(score, -clip, clip)
+            corr = np.corrcoef(score, r)[0, 1]
+            if np.isnan(corr):
+                continue
+            abs_corr = abs(corr)
+            if abs_corr > best_corr:
+                best_corr = abs_corr
+                best_c = float(c)
+                best_s = float(s if corr >= 0 else -s)
+
+    return {"center": best_c, "scale": best_s, "clip": clip}
+
+
+__all__ = ["ModelSignalCfg", "model_score_from_proba", "fit_center_scale"]

--- a/tests/signal/test_model_signal_calibration.py
+++ b/tests/signal/test_model_signal_calibration.py
@@ -1,0 +1,22 @@
+"""Tests for model signal calibration utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quant_trade.signal.model_signal import ModelSignalCfg, fit_center_scale
+
+
+def test_fit_center_scale_recovers_params():
+    proba = np.linspace(0.0, 1.0, 101)
+    future = np.tanh((proba - 0.5) * 3.0)
+    res = fit_center_scale(proba, future)
+    assert res["center"] == 0.5
+    assert res["scale"] == 3.0
+
+
+def test_model_signal_cfg_from_calibration_dict():
+    calib = {"center": 0.4, "scale": 2.0}
+    cfg = ModelSignalCfg.from_calibration(calib)
+    assert cfg.center == 0.4
+    assert cfg.scale == 2.0


### PR DESCRIPTION
## Summary
- allow ModelSignalCfg to load parameters from calibration results
- add fit_center_scale helper to tune center/scale for probabilities
- cover calibration workflow with tests

## Testing
- `pytest -q tests` *(fails: assertion errors in signal generator and other modules)*
- `pytest -q tests/signal/test_model_signal_calibration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0750064bc832a997f8cac8d7ee070