### PR TITLE
feat: support per-symbol thresholds

### DIFF
--- a/tests/signal/test_model_signal_symbol_cfg.py
+++ b/tests/signal/test_model_signal_symbol_cfg.py
@@ -1,0 +1,19 @@
+from quant_trade.signal.model_signal import ModelSignalCfg, model_score_from_proba
+
+
+def test_symbol_specific_thresholds_and_fallback():
+    cfg = ModelSignalCfg(
+        symbol_thresholds={"IF": {"p_min_up": 0.6, "p_min_down": 0.6, "margin_min": 0.5}}
+    )
+    proba = [0.2, 0.1, 0.7]
+    assert model_score_from_proba(proba, cfg, symbol="IF") is None
+    assert model_score_from_proba(proba, cfg, symbol="OTHER") == 1.0
+
+
+def test_symbol_specific_down_threshold():
+    cfg = ModelSignalCfg(
+        symbol_thresholds={"IF": {"p_min_up": 0.6, "p_min_down": 0.7, "margin_min": 0.1}}
+    )
+    proba = [0.65, 0.1, 0.1]
+    assert model_score_from_proba(proba, cfg, symbol="IF") is None
+    assert model_score_from_proba(proba, cfg, symbol="OTHER") == -1.0


### PR DESCRIPTION
## Summary
- allow `ModelSignalCfg` to carry symbol specific `p_min_up`, `p_min_down`, `margin_min`
- select thresholds in `model_score_from_proba` based on symbol with global fallback
- add tests for symbol-specific threshold behaviour

## Testing
- `pytest -q tests` *(fails: see logs for details)*
- `pytest -q tests/signal/test_model_signal_symbol_cfg.py`


------
https://chatgpt.com/codex/tasks/task_e_68a077445b8c832aa75d7f4a61c2f65c