### PR TITLE
feat: adaptive Kelly sizing with rolling stats

### DIFF
--- a/quant_trade/signal/__init__.py
+++ b/quant_trade/signal/__init__.py
@@ -4,7 +4,7 @@ from .core import generate_signal
 from .features_to_scores import get_factor_scores, get_factor_scores_batch
 from .ai_inference import get_period_ai_scores, get_reg_predictions
 from .multi_period_fusion import fuse_scores
-from .decision import DecisionConfig, decide_signal
+from .decision import DecisionConfig, decide_signal, RollingStats
 from .dynamic_thresholds import (
     DynamicThresholdInput,
     SignalThresholdParams,
@@ -37,6 +37,7 @@ __all__ = [
     "fuse_scores",
     "DecisionConfig",
     "decide_signal",
+    "RollingStats",
     "DynamicThresholdInput",
     "SignalThresholdParams",
     "DynamicThresholdParams",


### PR DESCRIPTION
## Summary
- add `RollingStats` to track rolling win rate and P/L ratio
- allow adaptive adjustment of `kelly_gamma` in `decide_signal`
- expose `RollingStats` and add adaptive toggle in `DecisionConfig`

## Testing
- `pytest -q tests/test_decision_module.py`
- `pytest -q tests` *(fails: assert 0.010956281570688927 <= 0.01, AttributeError: 'RobustSignalGenerator' object has no attribute 'predictor', ...)*


------
https://chatgpt.com/codex/tasks/task_e_68a085818f40832a9f7ca554020abe19